### PR TITLE
MMCA-4003 Import VAT certificates (C79) statements page changes for available/unavailable certificates

### DIFF
--- a/app/controllers/VatController.scala
+++ b/app/controllers/VatController.scala
@@ -85,6 +85,13 @@ class VatController @Inject()(val authenticate: IdentifierAction,
     } yield response
   }
 
+  /**
+   * Drops the immediate previous month's cert if the day for the current date is before 15th day
+   * of the month otherwise unchanged certs are returned
+   *
+   * @param currentCerts Seq[VatCertificatesByMonth] Certs populated for last 6 months
+   * @return Seq[VatCertificatesByMonth] Updated Certs as per the date check
+   */
   private def dropImmediatePreviousMonthCertIfUnavailable(currentCerts: Seq[VatCertificatesByMonth]): Seq[VatCertificatesByMonth] =
     if (isDayBefore15ThDayOfTheMonth(LocalDate.now) && currentCerts.head.files.isEmpty) {
       currentCerts.drop(1)

--- a/app/controllers/VatController.scala
+++ b/app/controllers/VatController.scala
@@ -85,10 +85,9 @@ class VatController @Inject()(val authenticate: IdentifierAction,
     } yield response
   }
 
-  private def dropImmediatePreviousMonthCertIfUnavailable(currentCerts: Seq[VatCertificatesByMonth]): Seq[VatCertificatesByMonth] = {
+  private def dropImmediatePreviousMonthCertIfUnavailable(currentCerts: Seq[VatCertificatesByMonth]): Seq[VatCertificatesByMonth] =
     if (isDayBefore15ThDayOfTheMonth(LocalDate.now) && currentCerts.head.files.isEmpty) {
       currentCerts.drop(1)
     } else
       currentCerts
-  }
 }

--- a/app/utils/DateUtils.scala
+++ b/app/utils/DateUtils.scala
@@ -1,0 +1,14 @@
+package utils
+
+import java.time.LocalDate
+
+object DateUtils {
+
+  /**
+   * Checks whether the input date's day of Month is before 15th day of the Month
+   *
+   * @param date: LocalDate
+   * @return Boolean
+   */
+  def isDayBefore15ThDayOfTheMonth(date: LocalDate): Boolean = date.getDayOfMonth < 15
+}

--- a/app/utils/DateUtils.scala
+++ b/app/utils/DateUtils.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import java.time.LocalDate

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -109,7 +109,6 @@ class VatControllerSpec extends SpecBase {
         status(result) mustBe OK
 
         if (!DateUtils.isDayBefore15ThDayOfTheMonth(LocalDate.now())) {
-          println("====== Inside before 15th Day clause when it is false")
           contentAsString(result) mustBe view(viewModel)(request, messages(app), appConfig).toString()
           val doc = Jsoup.parse(contentAsString(result))
 

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -74,7 +74,7 @@ class VatControllerSpec extends SpecBase {
       }
     }
 
-    "show the cert unavailable text for the relevant month when Cert files are retrieved " +
+    "display the cert unavailable text for the relevant month when cert files are retrieved " +
       "after 14th of the month and cert is not available" in new Setup {
 
       val currentCertificates = Seq(
@@ -110,8 +110,8 @@ class VatControllerSpec extends SpecBase {
       }
     }
 
-    "not show the cert row for the immediate previous month when Cert files are retrieved " +
-      "before 15th of the month and cert is not available" in new Setup {
+    "not display the cert row for the immediate previous month when cert files are retrieved " +
+      "before 15th of the month and cert is not available for immediate previous month" in new Setup {
 
       val currentCertificates: Seq[VatCertificatesByMonth] = Seq(
         VatCertificatesByMonth(date.minusMonths(2), Seq())(messages(app)),
@@ -152,7 +152,7 @@ class VatControllerSpec extends SpecBase {
       }
     }
 
-    "show all the certs' row when Cert files are retrieved before 15th of the month and cert is available" in new Setup {
+    "display all the certs' row when cert files are retrieved before 15th of the month and cert is available" in new Setup {
       val vatCertificateFile: VatCertificateFile = VatCertificateFile("name_04",
         "download_url_06",
         111L,

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -110,7 +110,7 @@ class VatControllerSpec extends SpecBase {
       }
     }
 
-    "should not show the cert row for the immediate previous month when Cert files are retrieved " +
+    "not show the cert row for the immediate previous month when Cert files are retrieved " +
       "before 15th of the month and cert is not available" in new Setup {
 
       val currentCertificates: Seq[VatCertificatesByMonth] = Seq(
@@ -152,7 +152,7 @@ class VatControllerSpec extends SpecBase {
       }
     }
 
-    "should show all the certs' row when Cert files are retrieved before 15th of the month and cert is available" in new Setup {
+    "show all the certs' row when Cert files are retrieved before 15th of the month and cert is available" in new Setup {
       val vatCertificateFile: VatCertificateFile = VatCertificateFile("name_04",
         "download_url_06",
         111L,

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -76,15 +76,6 @@ class VatControllerSpec extends SpecBase {
 
     "show the cert unavailable text for the relevant month when Cert files are retrieved " +
       "after 14th of the month and cert is not available" in new Setup {
-      val vatCertificateFile: VatCertificateFile = VatCertificateFile("name_04",
-        "download_url_06",
-        111L,
-        VatCertificateFileMetadata(date.minusMonths(1).getYear,
-          date.minusMonths(1).getMonthValue,
-          Pdf,
-          C79Certificate,
-          None),
-        "")(messages(app))
 
       val currentCertificates = Seq(
         VatCertificatesByMonth(date.minusMonths(1), Seq())(messages(app)),
@@ -129,7 +120,8 @@ class VatControllerSpec extends SpecBase {
         VatCertificatesByMonth(date.minusMonths(5), Seq())(messages(app)),
         VatCertificatesByMonth(date.minusMonths(6), Seq())(messages(app)),
       )
-      val vatCertificatesForEoris: Seq[VatCertificatesForEori] = Seq(VatCertificatesForEori(eoriHistory.head, currentCertificates, Seq.empty))
+      val vatCertificatesForEoris: Seq[VatCertificatesForEori] = Seq(VatCertificatesForEori(eoriHistory.head,
+        currentCertificates, Seq.empty))
       val viewModel: VatViewModel = VatViewModel(vatCertificatesForEoris)
 
       when(mockSdesConnector.getVatCertificates(anyString)(any, any))

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -151,6 +151,57 @@ class VatControllerSpec extends SpecBase {
         }
       }
     }
+
+    "should show all the certs' row when Cert files are retrieved before 15th of the month and cert is available" in new Setup {
+      val vatCertificateFile: VatCertificateFile = VatCertificateFile("name_04",
+        "download_url_06",
+        111L,
+        VatCertificateFileMetadata(date.minusMonths(1).getYear,
+          date.minusMonths(1).getMonthValue,
+          Pdf,
+          C79Certificate,
+          None),
+        "")(messages(app))
+
+      val currentCertificates: Seq[VatCertificatesByMonth] = Seq(
+        VatCertificatesByMonth(date.minusMonths(1), Seq(vatCertificateFile))(messages(app)),
+        VatCertificatesByMonth(date.minusMonths(2), Seq())(messages(app)),
+        VatCertificatesByMonth(date.minusMonths(3), Seq())(messages(app)),
+        VatCertificatesByMonth(date.minusMonths(4), Seq())(messages(app)),
+        VatCertificatesByMonth(date.minusMonths(5), Seq())(messages(app)),
+        VatCertificatesByMonth(date.minusMonths(6), Seq())(messages(app)),
+      )
+      val vatCertificatesForEoris: Seq[VatCertificatesForEori] = Seq(VatCertificatesForEori(eoriHistory.head,
+        currentCertificates, Seq.empty))
+      val viewModel: VatViewModel = VatViewModel(vatCertificatesForEoris)
+
+      when(mockSdesConnector.getVatCertificates(anyString)(any, any))
+        .thenReturn(Future.successful(Seq(vatCertificateFile)))
+
+      when(mockFinancialsApiConnector.deleteNotification(any, any)(any))
+        .thenReturn(Future.successful(true))
+
+      running(app) {
+        val request = fakeRequest(GET, routes.VatController.showVatAccount.url)
+        val result = route(app, request).value
+        status(result) mustBe OK
+
+        if (DateUtils.isDayBefore15ThDayOfTheMonth(LocalDate.now())) {
+          contentAsString(result) mustBe view(viewModel)(request, messages(app), appConfig).toString()
+          val doc = Jsoup.parse(contentAsString(result))
+
+          doc.getElementById("statements-list-0-row-0") should not be null
+          doc.getElementById("statements-list-0-row-1") should not be null
+          doc.getElementById("statements-list-0-row-2") should not be null
+          doc.getElementById("statements-list-0-row-3") should not be null
+          doc.getElementById("statements-list-0-row-4") should not be null
+          doc.getElementById("statements-list-0-row-5") should not be null
+
+          doc.getElementById("statements-list-0-row-0").children().text() should not include (messages(app)(
+            "cf.account.vat.statements.unavailable", Formatters.dateAsMonth(date.minusMonths(1))(messages(app))))
+        }
+      }
+    }
   }
 
   "certificatesUnavailablePage" should {

--- a/test/utils/DateUtilsSpec.scala
+++ b/test/utils/DateUtilsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import java.time.LocalDate

--- a/test/utils/DateUtilsSpec.scala
+++ b/test/utils/DateUtilsSpec.scala
@@ -24,7 +24,10 @@ class DateUtilsSpec extends SpecBase {
   "isBefore15ThDayOfTheMonth" should {
     "return true when input day is before 15th day of the current month" in {
       val dateBefore15ThDay: LocalDate = LocalDate.of(2023, 5, 12)
+      val dateOf14ThDayOfTheMonth: LocalDate = LocalDate.of(2023, 5, 14)
+
       isDayBefore15ThDayOfTheMonth(dateBefore15ThDay) shouldBe true
+      isDayBefore15ThDayOfTheMonth(dateOf14ThDayOfTheMonth) shouldBe true
     }
 
     "return false when input day is after 15th day of the current month" in {

--- a/test/utils/DateUtilsSpec.scala
+++ b/test/utils/DateUtilsSpec.scala
@@ -1,0 +1,24 @@
+package utils
+
+import java.time.LocalDate
+import utils.DateUtils.isDayBefore15ThDayOfTheMonth
+
+class DateUtilsSpec extends SpecBase {
+
+  "isBefore15ThDayOfTheMonth" should {
+    "return true when input day is before 15th day of the current month" in {
+      val dateBefore15ThDay: LocalDate = LocalDate.of(2023, 5, 12)
+      isDayBefore15ThDayOfTheMonth(dateBefore15ThDay) shouldBe true
+    }
+
+    "return false when input day is after 15th day of the current month" in {
+      val dateAfter15ThDay: LocalDate = LocalDate.of(2023, 4, 20)
+      isDayBefore15ThDayOfTheMonth(dateAfter15ThDay) shouldBe false
+    }
+
+    "return false when input day is 15th day of the current month" in {
+      val dateWith15ThDay: LocalDate = LocalDate.of(2023, 3, 15)
+      isDayBefore15ThDayOfTheMonth(dateWith15ThDay) shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
Code changes, not to show the immediate previous month cert row if the cert is not available and certs are accessed before 15th day of the month. A new utility method has been added.