### PR TITLE
[MMCA-4102] - Update version & configuration for CDS Financials service - July - V2

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,12 +3,12 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "7.15.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.7.0-play-28"
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "7.19.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.14.0-play-28"
   )
 
   val test = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-28" % "7.15.0" % Test,
+    "uk.gov.hmrc" %% "bootstrap-test-play-28" % "7.19.0" % Test,
     "org.jsoup" % "jsoup" % "1.13.1" % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8" % Test,
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,13 +2,15 @@ import sbt._
 
 object AppDependencies {
 
+  val bootstrapVersion = "7.19.0"
+
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "7.19.0",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.14.0-play-28"
   )
 
   val test = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-28" % "7.19.0" % Test,
+    "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion % Test,
     "org.jsoup" % "jsoup" % "1.13.1" % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8" % Test,
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,


### PR DESCRIPTION
Below libraries have been updated to the latest version

uk.gov.hmrc:bootstrap-backend-play-28
uk.gov.hmrc:bootstrap-test-play-28

uk.gov.hmrc:play-frontend-hmrc