### PR TITLE
[MMCA-4290] - Update version, configuration & warnings for CDS Financials service - Oct'23 - V4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val silencerVersion = "1.17.13"
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
-  .settings(scoverageSettings: _*)
+  .settings(scoverageSettings *)
   .settings(PlayKeys.playDefaultPort := 9398)
   .settings(
     majorVersion                     := 0,
@@ -24,7 +24,7 @@ lazy val microservice = Project(appName, file("."))
     // ***************
   )
   .configs(IntegrationTest)
-  .settings(integrationTestSettings(): _*)
+  .settings(integrationTestSettings() *)
   .settings(resolvers += Resolver.jcenterRepo)
 
 lazy val scoverageSettings = {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,20 +1,19 @@
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
   val bootstrapVersion = "7.22.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.21.0-play-28"
+    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.23.0-play-28"
   )
 
-  val test = Seq(
+  val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion % Test,
     "org.jsoup" % "jsoup" % "1.16.1" % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8" % Test,
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
     "org.mockito" %% "mockito-scala-scalatest" % "1.17.14" % Test,
-    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.21.0-play-28"
   )
 }


### PR DESCRIPTION
Description - Library updates and update to remove warnings

Below has been done as part of this PR

- Update uk.gov.hmrc: play-frontend-hmrc to 7.23.0-play-28
- Very minor refactoring
- Update to remove warnings for deprecated stuff
- Remove duplicated entry for uk.gov.hmrc:play-frontend-hmrc