### PR TITLE
[MMCA-4395] - Accessing bookmarked the page with undeliverable email address - '/customs/documents/import-vat - documents frontend'

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -37,6 +37,8 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   var historicStatementsEnabled: Boolean = config.get[Boolean]("features.historic-statements-enabled")
   lazy val customsDataStore: String = servicesConfig.baseUrl("customs-data-store") +
     config.get[String]("microservice.services.customs-data-store.context")
+  lazy val emailFrontendService: String = servicesConfig.baseUrl("customs-email-frontend") +
+    config.get[String]("microservice.services.customs-email-frontend.context")
 
   lazy val viewVatAccountSupportLink: String = config.get[String]("external-urls.viewVatAccountSupportLink")
 
@@ -49,7 +51,7 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   lazy val signOutUrl: String = config.get[String]("external-urls.signOut")
   lazy val requestedStatements: String = config.get[String]("external-urls.requestedStatements")
   lazy val historicRequest: String = config.get[String]("external-urls.historicRequest")
-  lazy val emailFrontendUrl: String = config.get[String]("microservice.services.customs-email-frontend.url")
+  lazy val emailFrontendUrl: String = s"$emailFrontendService/service/customs-finance"
   lazy val pvEmailEmailAddress: String = config.get[String]("external-urls.pvEmailEmailAddress")
   lazy val pvEmailEmailAddressHref: String = config.get[String]("external-urls.pvEmailEmailAddressHref")
   lazy val cdsEmailEnquiries: String = config.get[String]("external-urls.cdsEmailEnquiries")

--- a/app/connectors/FinancialsApiConnector.scala
+++ b/app/connectors/FinancialsApiConnector.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import config.AppConfig
-import models.{FileRole, EmailUnverifiedResponse}
+import models.{EmailUnverifiedResponse, EmailVerifiedResponse, FileRole}
 import play.mvc.Http.Status
 import services.MetricsReporterService
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
@@ -40,4 +40,7 @@ class FinancialsApiConnector @Inject()(appConfig: AppConfig,
   def isEmailUnverified(implicit hc: HeaderCarrier): Future[Option[String]] = {
     httpClient.GET[EmailUnverifiedResponse](appConfig.customsFinancialsApi + "/subscriptions/unverified-email-display").map( res => res.unVerifiedEmail)
   }
+
+  def verifiedEmail(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] =
+    httpClient.GET[EmailVerifiedResponse](appConfig.customsFinancialsApi + "/subscriptions/email-display")
 }

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -44,7 +44,9 @@ class EmailController @Inject()(authenticate: IdentifierAction,
     }
   }
 
-  def showUndeliverable(): Action[AnyContent] = authenticate { implicit request =>
-    Ok(undeliverableEmail(appConfig.emailFrontendUrl))
+  def showUndeliverable(): Action[AnyContent] = authenticate async { implicit request =>
+    financialsApiConnector.verifiedEmail.map {
+      verifiedEmailRes => Ok(undeliverableEmail(appConfig.emailFrontendUrl, verifiedEmailRes.verifiedEmail))
+    }
   }
 }

--- a/app/views/email/undeliverable_email.scala.html
+++ b/app/views/email/undeliverable_email.scala.html
@@ -21,25 +21,32 @@
 @this(
         p: p,
         h1: h1,
+        h2: h2,
         ul: unordered_list,
         button: button,
         layout: Layout
 )
-@(nextPage: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(
+    nextPage: String,
+    emailAddress: Option[String] = None
+)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @layout(pageTitle = Some(messages("cf.undeliverable.email.title"))) {
 
     @h1(msg = "cf.undeliverable.email.heading", classes = "govuk-heading-xl govuk-!-margin-bottom-4")
 
     @p("cf.undeliverable.email.p1")
-    @p("cf.undeliverable.email.p2")
-    @p("cf.undeliverable.email.p3")
 
-    @ul(
-        "cf.undeliverable.email.list.1",
-        "cf.undeliverable.email.list.2",
-        "cf.undeliverable.email.list.3"
-    )
+    @emailAddress.map(mailId => p(messages("cf.undeliverable.email.p2", mailId)))
 
-    @button("cf.undeliverable.email.link-text", Some(nextPage))
+    @h2(msg = "cf.undeliverable.email.verify.heading", classes = "govuk-heading-m govuk-!-margin-bottom-4")
+
+    @p("cf.undeliverable.email.verify.text.p1")
+
+    @h2(msg = "cf.undeliverable.email.change.heading", classes = "govuk-heading-m govuk-!-margin-bottom-4")
+
+    @p("cf.undeliverable.email.change.text.p1")
+    @p("cf.undeliverable.email.change.text.p2")
+
+    <p class="govuk-body">@button("cf.undeliverable.email.link-text", Some(nextPage))</p>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,7 +62,10 @@ microservice {
     }
 
     customs-email-frontend {
-      url = "/manage-email-cds/service/customs-finance"
+        protocol = http
+        host = localhost
+        port = 9898
+        context = "/manage-email-cds"
     }
 
     customs-data-store {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,10 +62,10 @@ microservice {
     }
 
     customs-email-frontend {
-        protocol = http
-        host = localhost
-        port = 9898
-        context = "/manage-email-cds"
+      protocol = http
+      host = localhost
+      port = 9898
+      context = "/manage-email-cds"
     }
 
     customs-data-store {

--- a/conf/messages
+++ b/conf/messages
@@ -171,14 +171,16 @@ cf.verify.your.email.link-text=Verify or change email address
 
 #Undeliverable Email Address
 # ------------------------------------------------------------------------
-cf.undeliverable.email.title=There''s a problem with the CDS registered email address
-cf.undeliverable.email.heading=There''s a problem with the CDS registered email address
-cf.undeliverable.email.p1=We tried to send you an email but it could not be delivered. This could be because the inbox is full, or due to a technical problem with your email provider.
-cf.undeliverable.email.p2=This is the email address your organisation has registered for the Customs Declaration Service (CDS). You need to verify this email address or change it. You can verify the email instantly provided you have access to the email account.
-cf.undeliverable.email.p3=This will be the only email address we use for:
-cf.undeliverable.email.list.1=updates on changes to the Customs Declaration Service
-cf.undeliverable.email.list.2=urgent updates about goods in customs
-cf.undeliverable.email.list.3=some financial notifications, including Direct Debit notices and VAT
+cf.undeliverable.email.title=There''s a problem with your email address for the Customs Declaration Service
+cf.undeliverable.email.heading=There''s a problem with your email address for the Customs Declaration Service
+cf.undeliverable.email.p1=We tried to send you an email but it could not be delivered.
+cf.undeliverable.email.p2=Your registered email address is <strong class="bold">{0}</strong>.
+
+cf.undeliverable.email.verify.heading=Verify your email address
+cf.undeliverable.email.verify.text.p1=If this email address is correct, you will need to verify it to continue using the Customs Declaration Service.
+cf.undeliverable.email.change.heading=Change your email address
+cf.undeliverable.email.change.text.p1=If this email address is not correct, you can change it here.
+cf.undeliverable.email.change.text.p2=The Customs Declaration Service uses one email address for various customs-related services. If you change it, take care that other people in your company will still have access to the messages they need.
 cf.undeliverable.email.link-text=Verify or change email address
 # ------------------------------------------------------------------------
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -172,14 +172,16 @@ cf.verify.your.email.link-text=Dilysu neu newid y cyfeiriad e-bost
 
 #Undeliverable Email Address
 # ------------------------------------------------------------------------
-cf.undeliverable.email.title=Mae problem gyda’r cyfeiriad e-bost cofrestredig ar gyfer y Gwasanaeth Datganiadau Tollau
-cf.undeliverable.email.heading=Mae problem gyda’r cyfeiriad e-bost cofrestredig ar gyfer y Gwasanaeth Datganiadau Tollau
-cf.undeliverable.email.p1=Gwnaethom geisio anfon e-bost atoch ond nid oedd modd ei ddosbarthu. Gallai hyn fod oherwydd bod y mewnflwch yn llawn, neu oherwydd bod problem dechnegol gyda’ch darparwr e-bost.
-cf.undeliverable.email.p2=Dyma’r cyfeiriad e-bost y mae’ch sefydliad wedi’i gofrestru ar gyfer y Gwasanaeth Datganiadau Tollau (CDS). Mae angen i chi ddilysu’r cyfeiriad e-bost hwn neu ei newid. Gallwch ddilysu’r cyfeiriad e-bost ar unwaith os oes gennych fynediad at y cyfrif e-bost.
-cf.undeliverable.email.p3=Dyma fydd yr unig gyfeiriad e-bost a ddefnyddiwn ar gyfer:
-cf.undeliverable.email.list.1=diweddariadau ar newidiadau i’r Gwasanaeth Datganiadau Tollau
-cf.undeliverable.email.list.2=diweddariadau brys am nwyddau yn y tollau
-cf.undeliverable.email.list.3=rhai hysbysiadau ariannol, gan gynnwys hysbysiadau Debyd Uniongyrchol a TAW
+cf.undeliverable.email.title=Mae problem gyda’ch cyfeiriad e-bost ar gyfer y Gwasanaeth Datganiadau Tollau
+cf.undeliverable.email.heading=Mae problem gyda’ch cyfeiriad e-bost ar gyfer y Gwasanaeth Datganiadau Tollau
+cf.undeliverable.email.p1=Gwnaethom geisio anfon e-bost atoch ond nid oedd modd ei ddosbarthu.
+cf.undeliverable.email.p2=Eich e-bost cofrestredig yw <strong class="bold">{0}</strong>.
+
+cf.undeliverable.email.verify.heading=Cadarnhau’ch cyfeiriad e-bost
+cf.undeliverable.email.verify.text.p1=Os mae’r cyfeiriad e-bost hwn yn gywir, bydd angen i chi ei gadarnhau er mwyn parhau i ddefnyddio Gwasanaeth Datganiadau Tollau.
+cf.undeliverable.email.change.heading=Newidiwch eich cyfeiriad e-bost
+cf.undeliverable.email.change.text.p1=Os nad yw’r cyfeiriad e-bost yn gywir, gallwch ei newid yma.
+cf.undeliverable.email.change.text.p2=Mae’r Gwasanaeth Datganiadau Tollau yn defnyddio un cyfeiriad e-bost ar gyfer nifer o wasanaethau sy’n gysylltiedig â thollau. Os ydych yn newid y cyfeiriad e-bost hwn, sicrhewch fod modd i bobl eraill yn eich cwmni gael y negeseuon sydd eu hangen arnynt.
 cf.undeliverable.email.link-text=Dilysu neu newid y cyfeiriad e-bost
 # ------------------------------------------------------------------------
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -93,6 +93,18 @@ class AppConfigSpec extends SpecBase {
     }
   }
 
+  "emailFrontendService" should {
+    "return the correct service address with context" in new Setup {
+      appConfig.emailFrontendService mustBe "http://localhost:9898/manage-email-cds"
+    }
+  }
+
+  "emailFrontendUrl" should {
+    "return the correct url" in new Setup {
+      appConfig.emailFrontendUrl mustBe "http://localhost:9898/manage-email-cds/service/customs-finance"
+    }
+  }
+
   trait Setup {
     val app: Application = application(allEoriHistory = Seq.empty).build()
     val appConfig: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -17,20 +17,22 @@
 package controllers
 
 import connectors.FinancialsApiConnector
-import models.EmailUnverifiedResponse
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import models.{EmailUnverifiedResponse, EmailVerifiedResponse}
+import play.api.Application
 import play.api.inject._
-import services.MetricsReporterService
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
-import utils.SpecBase
 import play.api.test.Helpers._
+import services.MetricsReporterService
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.SpecBase
 
 import scala.concurrent.Future
 
 class EmailControllerSpec extends SpecBase {
 
-  "EmailController" must {
+  "showUnverified" must {
     "return unverified email" in new Setup {
+      when(mockConnector.isEmailUnverified(any)).thenReturn(Future.successful(Some("unverifiedEmail")))
+
       running(app) {
         val connector = app.injector.instanceOf[FinancialsApiConnector]
 
@@ -40,6 +42,8 @@ class EmailControllerSpec extends SpecBase {
     }
 
     "return unverified email response" in new Setup {
+      when(mockConnector.isEmailUnverified(any)).thenReturn(Future.successful(Some("test@test.com")))
+
       running(app) {
         val request = fakeRequest(GET, routes.EmailController.showUnverified().url)
         val result = route(app, request).value
@@ -48,20 +52,33 @@ class EmailControllerSpec extends SpecBase {
     }
   }
 
+  "showUndeliverable" must {
+    "display undeliverableEmail page" in new Setup {
+
+      when(mockConnector.verifiedEmail(any)).thenReturn(Future.successful(emailVerifiedResponse))
+
+      running(app) {
+        val request = fakeRequest(GET, routes.EmailController.showUndeliverable().url)
+        val result = route(app, request).value
+
+        status(result) shouldBe OK
+      }
+    }
+  }
+
   trait Setup {
-    val expectedResult = Some("unverifiedEmail")
+    val expectedResult: Option[String] = Some("unverifiedEmail")
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    private val mockHttpClient = mock[HttpClient]
+
     val mockMetricsReporterService: MetricsReporterService = mock[MetricsReporterService]
+    val mockConnector: FinancialsApiConnector = mock[FinancialsApiConnector]
 
-    val response = EmailUnverifiedResponse(Some("unverifiedEmail"))
+    val response: EmailUnverifiedResponse = EmailUnverifiedResponse(Some("unverifiedEmail"))
+    val emailVerifiedResponse: EmailVerifiedResponse = EmailVerifiedResponse(Some("test@test.com"))
 
-    when[Future[EmailUnverifiedResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
-      .thenReturn(Future.successful(response))
-
-    val app = application().overrides(
+    val app: Application = application().overrides(
       bind[MetricsReporterService].toInstance(mockMetricsReporterService),
-      bind[HttpClient].toInstance(mockHttpClient)
+      bind[FinancialsApiConnector].toInstance(mockConnector)
     ).build()
   }
 }

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.email
+
+import config.AppConfig
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.Application
+import play.api.i18n.Messages
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import utils.SpecBase
+import views.html.email.undeliverable_email
+
+class UndeliverableEmailSpec extends SpecBase {
+
+  "view" should {
+    "display correct guidance and text" in new Setup {
+
+      view.title() mustBe
+        s"${messages(app)("cf.undeliverable.email.title")} - ${messages(app)("service.name")} - GOV.UK"
+
+      view.getElementsByTag("h1").text() mustBe messages(app)("cf.undeliverable.email.heading")
+
+      view.text().contains(messages(app)("cf.undeliverable.email.p1")) mustBe true
+      view.html.contains(messages(app)("cf.undeliverable.email.p2", email))
+
+      view.text().contains(messages(app)("cf.undeliverable.email.verify.heading")) mustBe true
+      view.text().contains(messages(app)("cf.undeliverable.email.verify.text.p1")) mustBe true
+      view.text().contains(messages(app)("cf.undeliverable.email.change.heading")) mustBe true
+
+      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p1")) mustBe true
+      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p2")) mustBe true
+
+      view.text().contains(messages(app)("cf.undeliverable.email.link-text")) mustBe true
+
+      view.toString should include(nextPageUrl)
+      view.text().contains(email.get) mustBe true
+    }
+
+    "not display the email paragraph if there is no email" in new Setup {
+      viewWithNoEmail.text().contains(email.get) mustBe false
+    }
+  }
+
+  trait Setup {
+    val app: Application = application().build()
+    val nextPageUrl = "test_url"
+    val email: Option[String] = Some("test@test.com")
+
+    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+    implicit val msg: Messages = messages(app)
+    implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
+
+    val view: Document = Jsoup.parse(
+      app.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
+
+    val viewWithNoEmail: Document = Jsoup.parse(
+      app.injector.instanceOf[undeliverable_email].apply(nextPageUrl).body)
+
+  }
+}


### PR DESCRIPTION
Description - Code changes to address when user is trying to access bookmarked page for import vat statements page and EORI has undeliverable email address associated with it

Below has been done as part of this PR

- New test class for the view
- Add new tests
- Relevant code changes
- Minor refactoring