### PR TITLE
[MMCA-5050] - Content changes on the 'Import VAT certificates' page

### DIFF
--- a/app/views/import_vat/import_vat_not_available.scala.html
+++ b/app/views/import_vat/import_vat_not_available.scala.html
@@ -59,7 +59,7 @@
         )
 
         @link(
-            "cf.account.pvat.older-statements.description.link",
+            "cf.account.vat.older-certificates.description.link",
             location = serviceUnavailableUrl.getOrElse(emptyString),
             preLinkMessage = Some("cf.account.vat.older-certificates.description.1")
         )

--- a/test/views/import_vat/ImportVatNotAvailableSpec.scala
+++ b/test/views/import_vat/ImportVatNotAvailableSpec.scala
@@ -44,6 +44,8 @@ class ImportVatNotAvailableSpec extends SpecBase {
       view.getElementById("vat.support.message.heading").html() mustBe
         messages(app)("cf.account.vat.support.heading")
 
+      view.html().contains(messages(app)("cf.account.vat.older-certificates.description.link"))
+      view.html().contains(messages(app)("cf.account.vat.older-certificates.description.1"))
       view.html().contains(messages(app)("cf.account.vat.older-certificates.description.2"))
       view.html().contains(messages(app)("cf.account.vat.support.link"))
       view.html().contains(serviceUnavailableUrl)

--- a/test/views/import_vat/ImportVatSpec.scala
+++ b/test/views/import_vat/ImportVatSpec.scala
@@ -59,7 +59,6 @@ class ImportVatSpec extends SpecBase {
       view.html().contains("cf.account.vat.older-certificates.description.2")
       view.html().contains("cf.account.vat.older-certificates.description.link")
       view.html().contains("cf.account.vat.older-certificates.description.1")
-      view.html().contains("cf.account.c-79.older-certificates.description.link")
       view.html().contains(appConfig.c79EmailAddressHref)
       view.html().contains(appConfig.c79EmailAddress)
       view.html().contains(serviceUnavailableUrl.getOrElse(emptyString))


### PR DESCRIPTION
**Context:**

This story is to replace 'statement' with 'certificate' on the 'Import VAT certificates' page. 

**Dev tasks:**

- [x] Update content as provided on the 'Import VAT certificates' page
- [x] Add/amend unit test cases
- [x] Make sure build passes