### PR TITLE
[MMCA-5056] -  remove targetJvm for Java 21 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import uk.gov.hmrc.DefaultBuildSettings.{targetJvm, itSettings}
+import uk.gov.hmrc.DefaultBuildSettings.itSettings
 import scoverage.ScoverageKeys
 
 val appName = "customs-financials-documents-frontend"
@@ -32,7 +32,6 @@ lazy val microservice = Project(appName, file("."))
   .settings(PlayKeys.playDefaultPort := 9398)
   .settings(scalastyleSettings)
   .settings(
-    targetJvm := "jvm-11",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     Assets / pipelineStages := Seq(gzip),
     scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),


### PR DESCRIPTION
- [x] Services will need to be on Play 2.9 or 3.0 and using sbt 1.9.7, Scala 2.13.12 to use it.
- [x] Remove `targetJvm` in build.sbt
- [x] Check that the service runs locally on Java 21 first.
- [x] Ensure build passes with Java 21.