### PR TITLE
[MMCA-5124] - Update Unit test structure to make use of common instance of application builder, AppConfig and Messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,12 @@ import scoverage.ScoverageKeys
 
 val appName = "customs-financials-documents-frontend"
 
-val silencerVersion = "1.7.16"
-val scala3_3_4 = "3.3.4"
+val silencerVersion  = "1.7.16"
+val scala3_3_4       = "3.3.4"
 val bootstrapVersion = "9.5.0"
 
-val testDirectory = "test"
-val scalaStyleConfigFile = "scalastyle-config.xml"
+val testDirectory            = "test"
+val scalaStyleConfigFile     = "scalastyle-config.xml"
 val testScalaStyleConfigFile = "test-scalastyle-config.xml"
 
 Global / lintUnusedKeysOnLoad := false
@@ -16,8 +16,10 @@ Global / lintUnusedKeysOnLoad := false
 ThisBuild / majorVersion := 0
 ThisBuild / scalaVersion := scala3_3_4
 
-lazy val scalastyleSettings = Seq(scalastyleConfig := baseDirectory.value / scalaStyleConfigFile,
-  (Test / scalastyleConfig) := baseDirectory.value / testDirectory / testScalaStyleConfigFile)
+lazy val scalastyleSettings = Seq(
+  scalastyleConfig := baseDirectory.value / scalaStyleConfigFile,
+  (Test / scalastyleConfig) := baseDirectory.value / testDirectory / testScalaStyleConfigFile
+)
 
 lazy val it = project
   .enablePlugins(PlayScala)
@@ -37,27 +39,33 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),
     scalacOptions += "-Wconf:msg=Flag.*repeatedly:s",
     Test / scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),
-    libraryDependencies ++= Seq(compilerPlugin(
-      "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.for3Use2_13With("", ".12")),
-      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.for3Use2_13With("", ".12")),
+    libraryDependencies ++= Seq(
+      compilerPlugin(
+        "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.for3Use2_13With("", ".12")
+      ),
+      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.for3Use2_13With("", ".12")
+    ),
     scalafmtDetailedError := true,
     scalafmtPrintDiff := true,
     scalafmtFailOnErrors := true
   )
   .settings(resolvers += Resolver.jcenterRepo)
 
-lazy val scoverageSettings = {
+lazy val scoverageSettings =
   Seq(
-    ScoverageKeys.coverageExcludedPackages := List("<empty>"
-      , "Reverse.*"
-      , ".*views.*"
-      , ".*(BuildInfo|Routes|testOnly).*").mkString(";"),
+    ScoverageKeys.coverageExcludedPackages := List(
+      "<empty>",
+      "Reverse.*",
+      ".*views.*",
+      ".*(BuildInfo|Routes|testOnly).*"
+    ).mkString(";"),
     ScoverageKeys.coverageMinimumBranchTotal := 90,
     ScoverageKeys.coverageMinimumStmtTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := false,
     ScoverageKeys.coverageHighlighting := true
   )
-}
 
-addCommandAlias("runAllChecks",
-  ";clean;compile;coverage;test;it/test;scalafmtCheckAll;scalastyle;Test/scalastyle;coverageReport")
+addCommandAlias(
+  "runAllChecks",
+  ";clean;compile;coverage;test;it/test;scalafmtCheckAll;scalastyle;Test/scalastyle;coverageReport"
+)

--- a/test/actions/AuthActionSpec.scala
+++ b/test/actions/AuthActionSpec.scala
@@ -17,7 +17,6 @@
 package actions
 
 import com.google.inject.Inject
-import config.AppConfig
 import connectors.DataStoreConnector
 import play.api.{Application, inject}
 import play.api.mvc.{Action, AnyContent, BodyParsers, Results}

--- a/test/actions/AuthActionSpec.scala
+++ b/test/actions/AuthActionSpec.scala
@@ -52,26 +52,25 @@ class AuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
-        new AuthAction(new FakeFailingAuthConnector(new MissingBearerToken), config, bodyParsers, authActionHelper)
+        new AuthAction(new FakeFailingAuthConnector(new MissingBearerToken), appConfig, bodyParsers, authActionHelper)
 
       val controller = new Harness(authAction)
 
       running(app) {
         val result = controller.onPageLoad()(fakeRequest().withHeaders("X-Session-Id" -> "someSessionId"))
         status(result) mustBe SEE_OTHER
-        redirectLocation(result).get must startWith(config.loginUrl)
+        redirectLocation(result).get must startWith(appConfig.loginUrl)
       }
     }
 
@@ -79,19 +78,18 @@ class AuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
-        new AuthAction(new FakeFailingAuthConnector(new BearerTokenExpired), config, bodyParsers, authActionHelper)
+        new AuthAction(new FakeFailingAuthConnector(new BearerTokenExpired), appConfig, bodyParsers, authActionHelper)
 
       val controller = new Harness(authAction)
 
@@ -99,7 +97,7 @@ class AuthActionSpec extends SpecBase {
         val result = controller.onPageLoad()(fakeRequest().withHeaders("X-Session-Id" -> "someSessionId"))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result).get must startWith(config.loginUrl)
+        redirectLocation(result).get must startWith(appConfig.loginUrl)
       }
     }
 
@@ -107,19 +105,23 @@ class AuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
-        new AuthAction(new FakeFailingAuthConnector(new UnsupportedAuthProvider), config, bodyParsers, authActionHelper)
+        new AuthAction(
+          new FakeFailingAuthConnector(new UnsupportedAuthProvider),
+          appConfig,
+          bodyParsers,
+          authActionHelper
+        )
 
       val controller = new Harness(authAction)
 
@@ -135,19 +137,23 @@ class AuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
-        new AuthAction(new FakeFailingAuthConnector(new InsufficientEnrolments), config, bodyParsers, authActionHelper)
+        new AuthAction(
+          new FakeFailingAuthConnector(new InsufficientEnrolments),
+          appConfig,
+          bodyParsers,
+          authActionHelper
+        )
 
       val controller = new Harness(authAction)
 

--- a/test/actions/AuthActionSpec.scala
+++ b/test/actions/AuthActionSpec.scala
@@ -59,8 +59,8 @@ class AuthActionSpec extends SpecBase {
         )
         .build()
 
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
         new AuthAction(new FakeFailingAuthConnector(new MissingBearerToken), appConfig, bodyParsers, authActionHelper)
@@ -85,8 +85,8 @@ class AuthActionSpec extends SpecBase {
         )
         .build()
 
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
         new AuthAction(new FakeFailingAuthConnector(new BearerTokenExpired), appConfig, bodyParsers, authActionHelper)
@@ -112,8 +112,8 @@ class AuthActionSpec extends SpecBase {
         )
         .build()
 
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
         new AuthAction(
@@ -144,8 +144,8 @@ class AuthActionSpec extends SpecBase {
         )
         .build()
 
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
         new AuthAction(

--- a/test/actions/EmailActionSpec.scala
+++ b/test/actions/EmailActionSpec.scala
@@ -80,7 +80,7 @@ class EmailActionSpec extends SpecBase {
   trait Setup {
     val mockDataStoreConnector: DataStoreConnector = mock[DataStoreConnector]
 
-    val app: Application = application()
+    val app: Application = applicationBuilder()
       .overrides(
         inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
       )

--- a/test/actions/EmailActionSpec.scala
+++ b/test/actions/EmailActionSpec.scala
@@ -86,7 +86,7 @@ class EmailActionSpec extends SpecBase {
       )
       .build()
 
-    val emailAction: EmailAction = app.injector.instanceOf[EmailAction]
+    val emailAction: EmailAction = instanceOf[EmailAction](app)
 
     val authenticatedRequest: AuthenticatedRequest[AnyContentAsEmpty.type] =
       AuthenticatedRequest(FakeRequest("GET", "/"), "someEori", Seq.empty)

--- a/test/actions/PvatAuthActionSpec.scala
+++ b/test/actions/PvatAuthActionSpec.scala
@@ -41,19 +41,19 @@ class PvatAuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
+
       val bodyParsers      = app.injector.instanceOf[Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
-        new PvatAuthAction(new FakeFailingAuthConnector(new MissingBearerToken), config, bodyParsers, authActionHelper)
+        new PvatAuthAction(new FakeFailingAuthConnector(new MissingBearerToken), appConfig, bodyParsers, authActionHelper)
 
       val controller = new Harness(authAction)
 
@@ -71,19 +71,19 @@ class PvatAuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
+
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
-        new PvatAuthAction(new FakeFailingAuthConnector(new BearerTokenExpired), config, bodyParsers, authActionHelper)
+        new PvatAuthAction(new FakeFailingAuthConnector(new BearerTokenExpired), appConfig, bodyParsers, authActionHelper)
 
       val controller = new Harness(authAction)
 
@@ -91,7 +91,7 @@ class PvatAuthActionSpec extends SpecBase {
         val result = controller.onPageLoad()(fakeRequest().withHeaders("X-Session-Id" -> "someSessionId"))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result).get must startWith(config.loginUrl)
+        redirectLocation(result).get must startWith(appConfig.loginUrl)
       }
     }
 
@@ -99,21 +99,21 @@ class PvatAuthActionSpec extends SpecBase {
       val mockAuditingService    = mock[AuditingService]
       val mockDataStoreConnector = mock[DataStoreConnector]
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
+
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
       val authAction =
         new PvatAuthAction(
           new FakeFailingAuthConnector(new UnsupportedAuthProvider),
-          config,
+          appConfig,
           bodyParsers,
           authActionHelper
         )
@@ -149,18 +149,18 @@ class PvatAuthActionSpec extends SpecBase {
           )
         )
 
-      val app = application()
+      val app = applicationBuilder()
         .overrides(
           inject.bind[AuditingService].toInstance(mockAuditingService),
           inject.bind[DataStoreConnector].toInstance(mockDataStoreConnector)
         )
         .build()
 
-      val config           = app.injector.instanceOf[AppConfig]
+
       val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
       val authActionHelper = app.injector.instanceOf[AuthActionHelper]
 
-      val authAction = new PvatAuthAction(mockAuthConnector, config, bodyParsers, authActionHelper)
+      val authAction = new PvatAuthAction(mockAuthConnector, appConfig, bodyParsers, authActionHelper)
       val controller = new Harness(authAction)
 
       running(app) {

--- a/test/actions/PvatAuthActionSpec.scala
+++ b/test/actions/PvatAuthActionSpec.scala
@@ -48,12 +48,16 @@ class PvatAuthActionSpec extends SpecBase {
         )
         .build()
 
-
-      val bodyParsers      = app.injector.instanceOf[Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
-        new PvatAuthAction(new FakeFailingAuthConnector(new MissingBearerToken), appConfig, bodyParsers, authActionHelper)
+        new PvatAuthAction(
+          new FakeFailingAuthConnector(new MissingBearerToken),
+          appConfig,
+          bodyParsers,
+          authActionHelper
+        )
 
       val controller = new Harness(authAction)
 
@@ -78,12 +82,16 @@ class PvatAuthActionSpec extends SpecBase {
         )
         .build()
 
-
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
-        new PvatAuthAction(new FakeFailingAuthConnector(new BearerTokenExpired), appConfig, bodyParsers, authActionHelper)
+        new PvatAuthAction(
+          new FakeFailingAuthConnector(new BearerTokenExpired),
+          appConfig,
+          bodyParsers,
+          authActionHelper
+        )
 
       val controller = new Harness(authAction)
 
@@ -106,9 +114,8 @@ class PvatAuthActionSpec extends SpecBase {
         )
         .build()
 
-
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction =
         new PvatAuthAction(
@@ -156,9 +163,8 @@ class PvatAuthActionSpec extends SpecBase {
         )
         .build()
 
-
-      val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
-      val authActionHelper = app.injector.instanceOf[AuthActionHelper]
+      val bodyParsers      = instanceOf[BodyParsers.Default](app)
+      val authActionHelper = instanceOf[AuthActionHelper](app)
 
       val authAction = new PvatAuthAction(mockAuthConnector, appConfig, bodyParsers, authActionHelper)
       val controller = new Harness(authAction)

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -18,64 +18,50 @@ package config
 
 import models.FileRole
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
 import play.api.test.Helpers.running
 
-class AppConfigSpec extends SpecBase {
+class AppConfigSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "FrontendAppConfig" should {
 
     "include the app name" in {
-      running(application) {
-        appConfig.appName mustBe "customs-financials-documents-frontend"
-      }
+      appConfig.appName mustBe "customs-financials-documents-frontend"
     }
 
     "historic request url" should {
       "contain 'adjustments'" in {
-        running(application) {
-          appConfig.historicRequestUrl(FileRole.SecurityStatement) must include("adjustments")
-        }
+        appConfig.historicRequestUrl(FileRole.SecurityStatement) must include("adjustments")
       }
 
       "contain 'import-vat'" in {
-        running(application) {
-          appConfig.historicRequestUrl(FileRole.C79Certificate) must include("import-vat")
-        }
+        appConfig.historicRequestUrl(FileRole.C79Certificate) must include("import-vat")
       }
 
       "return empty string for invalid filerole" in {
-        running(application) {
-          appConfig.historicRequestUrl(FileRole.PostponedVATAmendedStatement) mustBe empty
-        }
+        appConfig.historicRequestUrl(FileRole.PostponedVATAmendedStatement) mustBe empty
       }
     }
 
     "requested statements url" should {
       "contain adjustments" in {
-        running(application) {
-          appConfig.requestedStatements(FileRole.SecurityStatement) must include("adjustments")
-        }
+        appConfig.requestedStatements(FileRole.SecurityStatement) must include("adjustments")
       }
 
       "contain import-vat" in {
-        running(application) {
-          appConfig.requestedStatements(FileRole.C79Certificate) must include("import-vat")
-        }
+        appConfig.requestedStatements(FileRole.C79Certificate) must include("import-vat")
       }
 
       "return empty string for invalid filerole" in {
-        running(application) {
-          appConfig.requestedStatements(FileRole.PostponedVATAmendedStatement) mustBe empty
-        }
+        appConfig.requestedStatements(FileRole.PostponedVATAmendedStatement) mustBe empty
       }
     }
 
     "contain correct subscribeCdsUrl" in {
-      appConfig.subscribeCdsUrl mustBe
-        "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
+      appConfig.subscribeCdsUrl mustBe "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
     }
 
     "contain correct contactFrontEndServiceId" in {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -18,7 +18,6 @@ package config
 
 import models.FileRole
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
@@ -28,62 +27,62 @@ class AppConfigSpec extends SpecBase {
 
   "FrontendAppConfig" should {
 
-    "include the app name" in new Setup {
-      running(app) {
+    "include the app name" in {
+      running(application) {
         appConfig.appName mustBe "customs-financials-documents-frontend"
       }
     }
 
     "historic request url" should {
-      "contain 'adjustments'" in new Setup {
-        running(app) {
+      "contain 'adjustments'" in {
+        running(application) {
           appConfig.historicRequestUrl(FileRole.SecurityStatement) must include("adjustments")
         }
       }
 
-      "contain 'import-vat'" in new Setup {
-        running(app) {
+      "contain 'import-vat'" in {
+        running(application) {
           appConfig.historicRequestUrl(FileRole.C79Certificate) must include("import-vat")
         }
       }
 
-      "return empty string for invalid filerole" in new Setup {
-        running(app) {
+      "return empty string for invalid filerole" in {
+        running(application) {
           appConfig.historicRequestUrl(FileRole.PostponedVATAmendedStatement) mustBe empty
         }
       }
     }
 
     "requested statements url" should {
-      "contain adjustments" in new Setup {
-        running(app) {
+      "contain adjustments" in {
+        running(application) {
           appConfig.requestedStatements(FileRole.SecurityStatement) must include("adjustments")
         }
       }
 
-      "contain import-vat" in new Setup {
-        running(app) {
+      "contain import-vat" in {
+        running(application) {
           appConfig.requestedStatements(FileRole.C79Certificate) must include("import-vat")
         }
       }
 
-      "return empty string for invalid filerole" in new Setup {
-        running(app) {
+      "return empty string for invalid filerole" in {
+        running(application) {
           appConfig.requestedStatements(FileRole.PostponedVATAmendedStatement) mustBe empty
         }
       }
     }
 
-    "contain correct subscribeCdsUrl" in new Setup {
+    "contain correct subscribeCdsUrl" in {
       appConfig.subscribeCdsUrl mustBe
         "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
     }
 
-    "contain correct contactFrontEndServiceId" in new Setup {
+    "contain correct contactFrontEndServiceId" in {
       appConfig.contactFrontEndServiceId mustBe "CDS Financials"
     }
 
-    "return correct value for deskProLinkUrlForServiceUnavailable" in new Setup {
+    "return correct value for deskProLinkUrlForServiceUnavailable" in {
       val path                                                     = "test_Path"
       implicit val reqHeaders: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", path)
 
@@ -94,19 +93,14 @@ class AppConfigSpec extends SpecBase {
   }
 
   "emailFrontendService" should {
-    "return the correct service address with context" in new Setup {
+    "return the correct service address with context" in {
       appConfig.emailFrontendService mustBe "http://localhost:9898/manage-email-cds"
     }
   }
 
   "emailFrontendUrl" should {
-    "return the correct url" in new Setup {
+    "return the correct url" in {
       appConfig.emailFrontendUrl mustBe "http://localhost:9898/manage-email-cds/service/customs-finance"
     }
-  }
-
-  trait Setup {
-    val app: Application     = application(allEoriHistory = Seq.empty).build()
-    val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
   }
 }

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -154,7 +154,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
   "verifiedEmail" should {
     "return EmailVerifiedResponse with email when the API returns a valid response" in new Setup {
-      val emailResponse = EmailVerifiedResponse(Some("verified@email.com"))
+      val emailResponse: EmailVerifiedResponse = EmailVerifiedResponse(Some("verified@email.com"))
 
       when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.successful(emailResponse))
@@ -180,7 +180,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
   "retrieveUnverifiedEmail" should {
     "return EmailUnverifiedResponse with email when the API returns a valid response" in new Setup {
-      val unverifiedEmailResponse = EmailUnverifiedResponse(Some("unverified@email.com"))
+      val unverifiedEmailResponse: EmailUnverifiedResponse = EmailUnverifiedResponse(Some("unverified@email.com"))
 
       when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.successful(unverifiedEmailResponse))

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -209,7 +209,7 @@ class DataStoreConnectorSpec extends SpecBase {
     val mockHttpClient: HttpClientV2                       = mock[HttpClientV2]
     val requestBuilder: RequestBuilder                     = mock[RequestBuilder]
 
-    val app: Application = application()
+    val app: Application = applicationBuilder()
       .overrides(
         inject.bind[MetricsReporterService].toInstance(mockMetricsReporterService),
         inject.bind[HttpClientV2].toInstance(mockHttpClient)

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -217,6 +217,6 @@ class DataStoreConnectorSpec extends SpecBase {
       .build()
 
     implicit val hc: HeaderCarrier    = HeaderCarrier()
-    val connector: DataStoreConnector = app.injector.instanceOf[DataStoreConnector]
+    val connector: DataStoreConnector = instanceOf[DataStoreConnector](app)
   }
 }

--- a/test/connectors/FinancialsApiConnectorSpec.scala
+++ b/test/connectors/FinancialsApiConnectorSpec.scala
@@ -54,7 +54,7 @@ class FinancialsApiConnectorSpec extends SpecBase {
     val mockHttpClient: HttpClientV2                       = mock[HttpClientV2]
     val requestBuilder: RequestBuilder                     = mock[RequestBuilder]
 
-    val app: Application = application()
+    val app: Application = applicationBuilder()
       .overrides(
         inject.bind[MetricsReporterService].toInstance(mockMetricsReporterService),
         inject.bind[HttpClientV2].toInstance(mockHttpClient)

--- a/test/connectors/FinancialsApiConnectorSpec.scala
+++ b/test/connectors/FinancialsApiConnectorSpec.scala
@@ -62,6 +62,6 @@ class FinancialsApiConnectorSpec extends SpecBase {
       .build()
 
     implicit val hc: HeaderCarrier        = HeaderCarrier()
-    val connector: FinancialsApiConnector = app.injector.instanceOf[FinancialsApiConnector]
+    val connector: FinancialsApiConnector = instanceOf[FinancialsApiConnector](app)
   }
 }

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -50,7 +50,7 @@ class SdesConnectorSpec extends SpecBase {
       "make a GET request to sdesSecurityStatementsUrl" in new Setup {
 
         val urlLink: URL               = url"$sdesSecurityStatementsUrl"
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
         when(mockHttp.get(any)(any)).thenReturn(requestBuilder)
@@ -64,7 +64,7 @@ class SdesConnectorSpec extends SpecBase {
       "filter out unknown file types" in new Setup {
 
         val urlLink: URL               = url"$sdesSecurityStatementsUrl"
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
         when(mockHttp.get(any)(any)).thenReturn(requestBuilder)
@@ -103,7 +103,7 @@ class SdesConnectorSpec extends SpecBase {
           )
           .build()
 
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         await(sdesService.getSecurityStatements(someEori)(hc))
 
@@ -117,7 +117,7 @@ class SdesConnectorSpec extends SpecBase {
       "filter out unknown file types" in new Setup {
 
         val urlLink                    = url"$sdesVatCertificatesUrl"
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
         when(mockHttp.get(any)(any)).thenReturn(requestBuilder)
@@ -157,7 +157,7 @@ class SdesConnectorSpec extends SpecBase {
           )
           .build()
 
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         await(sdesService.getVatCertificates(someEori)(hc, messages))
 
@@ -170,7 +170,7 @@ class SdesConnectorSpec extends SpecBase {
 
       "filter out unknown file types" in new Setup {
         val urlLink: URL               = url"$sdesPostponedVatStatementsUrl"
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
         when(mockHttp.get(any)(any)).thenReturn(requestBuilder)
@@ -214,7 +214,7 @@ class SdesConnectorSpec extends SpecBase {
           )
           .build()
 
-        val sdesService: SdesConnector = app.injector.instanceOf[SdesConnector]
+        val sdesService: SdesConnector = instanceOf[SdesConnector](app)
 
         await(sdesService.getPostponedVatStatements(someEori)(hc))
 

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -96,7 +96,7 @@ class SdesConnectorSpec extends SpecBase {
 
         when(sdesGatekeeperServiceSpy.convertTo(any())).thenCallRealMethod()
 
-        override val app: Application = application()
+        override val app: Application = applicationBuilder()
           .overrides(
             inject.bind[HttpClientV2].toInstance(mockHttp),
             inject.bind[SdesGatekeeperService].toInstance(sdesGatekeeperServiceSpy)
@@ -150,7 +150,7 @@ class SdesConnectorSpec extends SpecBase {
 
         when(sdesGatekeeperServiceSpy.convertTo(any())).thenCallRealMethod()
 
-        override val app: Application = application()
+        override val app: Application = applicationBuilder()
           .overrides(
             inject.bind[HttpClientV2].toInstance(mockHttp),
             inject.bind[SdesGatekeeperService].toInstance(sdesGatekeeperServiceSpy)
@@ -207,7 +207,7 @@ class SdesConnectorSpec extends SpecBase {
 
         when(sdesGatekeeperServiceSpy.convertTo(any())).thenCallRealMethod()
 
-        override val app: Application = application()
+        override val app: Application = applicationBuilder()
           .overrides(
             inject.bind[HttpClientV2].toInstance(mockHttp),
             inject.bind[SdesGatekeeperService].toInstance(sdesGatekeeperServiceSpy)
@@ -637,7 +637,7 @@ class SdesConnectorSpec extends SpecBase {
     val mockMetricsReporterService: MetricsReporterService = mock[MetricsReporterService]
     val mockAuditingService: AuditingService               = mock[AuditingService]
 
-    val app: Application = application().overrides(inject.bind[HttpClientV2].toInstance(mockHttp)).build()
+    val app: Application = applicationBuilder().overrides(inject.bind[HttpClientV2].toInstance(mockHttp)).build()
 
     private def getVatCertificateFileMetadata(
       periodStartYear: Int = YEAR_2018,

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import connectors.DataStoreConnector
 import models.{EmailUnverifiedResponse, EmailVerifiedResponse}
-import play.api.Application
+
 import play.api.inject._
 import play.api.test.Helpers._
 import services.MetricsReporterService
@@ -27,6 +27,7 @@ import utils.SpecBase
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import scala.concurrent.Future
+import play.api.Application
 
 class EmailControllerSpec extends SpecBase {
 
@@ -82,7 +83,7 @@ class EmailControllerSpec extends SpecBase {
     val emailUnverifiedResponseWithNoEmailId: EmailUnverifiedResponse = EmailUnverifiedResponse(None)
     val emailVerifiedResponse: EmailVerifiedResponse                  = EmailVerifiedResponse(Some("test@test.com"))
 
-    val app: Application = application()
+    val app: Application = applicationBuilder()
       .overrides(
         bind[MetricsReporterService].toInstance(mockMetricsReporterService),
         bind[DataStoreConnector].toInstance(mockConnector)

--- a/test/controllers/LogoutControllerSpec.scala
+++ b/test/controllers/LogoutControllerSpec.scala
@@ -27,7 +27,9 @@ class LogoutControllerSpec extends SpecBase {
   "logout" should {
 
     "redirect to logout link with survey continue" in {
-      running(application) {
+      val app = applicationBuilder.build()
+
+      running(app) {
         val request = fakeRequest(GET, routes.LogoutController.logout.url)
         val result  = route(application, request).value
 
@@ -41,9 +43,11 @@ class LogoutControllerSpec extends SpecBase {
   "logoutNoSurvey" should {
 
     "redirect to logout link without survey continue" in {
-      running(application) {
+      val app = applicationBuilder.build()
+
+      running(app) {
         val request = fakeRequest(GET, routes.LogoutController.logoutNoSurvey.url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe

--- a/test/controllers/LogoutControllerSpec.scala
+++ b/test/controllers/LogoutControllerSpec.scala
@@ -16,9 +16,7 @@
 
 package controllers
 
-import config.AppConfig
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
 import play.api.test.Helpers._
 import utils.SpecBase
 
@@ -28,34 +26,29 @@ class LogoutControllerSpec extends SpecBase {
 
   "logout" should {
 
-    "redirect to logout link with survey continue" in new Setup {
-      running(app) {
+    "redirect to logout link with survey continue" in {
+      running(application) {
         val request = fakeRequest(GET, routes.LogoutController.logout.url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe
-          s"${config.signOutUrl}?continue=${URLEncoder.encode(config.feedbackService, "UTF-8")}"
+          s"${appConfig.signOutUrl}?continue=${URLEncoder.encode(appConfig.feedbackService, "UTF-8")}"
       }
     }
   }
 
   "logoutNoSurvey" should {
 
-    "redirect to logout link without survey continue" in new Setup {
-      running(app) {
+    "redirect to logout link without survey continue" in {
+      running(application) {
         val request = fakeRequest(GET, routes.LogoutController.logoutNoSurvey.url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe
-          s"${config.signOutUrl}?continue=${URLEncoder.encode(config.loginContinueUrl, "UTF-8")}"
+          s"${appConfig.signOutUrl}?continue=${URLEncoder.encode(appConfig.loginContinueUrl, "UTF-8")}"
       }
     }
-  }
-
-  trait Setup {
-    val app: Application  = application().build()
-    val config: AppConfig = app.injector.instanceOf[AppConfig]
   }
 }

--- a/test/controllers/LogoutControllerSpec.scala
+++ b/test/controllers/LogoutControllerSpec.scala
@@ -31,7 +31,7 @@ class LogoutControllerSpec extends SpecBase {
 
       running(app) {
         val request = fakeRequest(GET, routes.LogoutController.logout.url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result).value mustBe

--- a/test/controllers/PostponedVatControllerSpec.scala
+++ b/test/controllers/PostponedVatControllerSpec.scala
@@ -289,8 +289,8 @@ class PostponedVatControllerSpec extends SpecBase {
   "statementsUnavailablePage" should {
     "display the view correctly" in {
 
-      val view      = application.injector.instanceOf[postponed_import_vat_not_available]
-      val navigator = application.injector.instanceOf[Navigator]
+      val view      = instanceOf[postponed_import_vat_not_available](application)
+      val navigator = instanceOf[Navigator](application)
 
       val serviceUnavailableUrl: String =
         routes.ServiceUnavailableController.onPageLoad(navigator.postponedVatNotAvailablePageId).url
@@ -712,9 +712,9 @@ class PostponedVatControllerSpec extends SpecBase {
         )
         .build()
 
-    val appConfig1: AppConfig = app.injector.instanceOf[AppConfig]
+    val appConfig1: AppConfig = instanceOf[AppConfig](app)
 
-    val view: postponed_import_vat = app.injector.instanceOf[postponed_import_vat]
+    val view: postponed_import_vat = instanceOf[postponed_import_vat](app)
 
     private def monthValueOfCurrentDate(monthValueToSubtract: Int): Int =
       LocalDate.now().minusMonths(monthValueToSubtract).getMonthValue

--- a/test/controllers/PostponedVatControllerSpec.scala
+++ b/test/controllers/PostponedVatControllerSpec.scala
@@ -48,7 +48,7 @@ class PostponedVatControllerSpec extends SpecBase {
   "show" should {
 
     "display the PostponedVat page with one column(CDS) for statements" in new Setup {
-      appConfig.historicStatementsEnabled = false
+      appConfig1.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -89,7 +89,7 @@ class PostponedVatControllerSpec extends SpecBase {
     }
 
     "display the PostponedVat page with two columns (CHIEF and CDS) for last 6 months" in new Setup {
-      appConfig.historicStatementsEnabled = false
+      appConfig1.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -121,7 +121,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "display the PostponedVat page with one column(CDS) " +
       "and Ignore historic CHIEF statements older than 6 months" in new Setup {
-        appConfig.historicStatementsEnabled = false
+        appConfig1.historicStatementsEnabled = false
 
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -182,7 +182,7 @@ class PostponedVatControllerSpec extends SpecBase {
               hasRequestedStatements = true,
               isCdsOnly = true,
               location = Some(cdsLocation),
-              urls = pvatUrls.copy(serviceUnavailableUrl = Some(appConfig.historicRequestUrl(PostponedVATStatement)))
+              urls = pvatUrls.copy(serviceUnavailableUrl = Some(appConfig1.historicRequestUrl(PostponedVATStatement)))
             )(messages, mockDateTimeService)
           )(request, messages, appConfig).toString()
 
@@ -203,7 +203,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "not display the immediate previous month statement on PostponedVat page when accessed " +
       "before 20th day of the month and statement is not available" in new Setup {
-        appConfig.historicStatementsEnabled = false
+        appConfig1.historicStatementsEnabled = false
 
         val currentDate: LocalDate = LocalDate.of(date.getYear, date.getMonthValue, DAY_12)
 
@@ -248,9 +248,9 @@ class PostponedVatControllerSpec extends SpecBase {
       }
 
     "display historic statements Url when feature is enabled" in new Setup {
-      appConfig.historicStatementsEnabled = true
+      appConfig1.historicStatementsEnabled = true
 
-      val historicRequestUrl: String = appConfig.historicRequestUrl(PostponedVATStatement)
+      val historicRequestUrl: String = appConfig1.historicRequestUrl(PostponedVATStatement)
       val currentDate: LocalDate     = LocalDate.of(date.getYear, date.getMonthValue, DAY_12)
 
       when(mockDataStoreConnector.getEmail(any)(any))
@@ -310,7 +310,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "when exception occurs in get postponedVAT statements api" in new Setup {
 
-      appConfig.historicStatementsEnabled = false
+      appConfig1.historicStatementsEnabled = false
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
       when(mockDataStoreConnector.getEmail(any)(any))
@@ -712,6 +712,8 @@ class PostponedVatControllerSpec extends SpecBase {
         )
         .build()
 
+    val appConfig1: AppConfig = app.injector.instanceOf[AppConfig]
+
     val view: postponed_import_vat = app.injector.instanceOf[postponed_import_vat]
 
     private def monthValueOfCurrentDate(monthValueToSubtract: Int): Int =
@@ -721,10 +723,10 @@ class PostponedVatControllerSpec extends SpecBase {
       LocalDate.now().minusMonths(monthValueToSubtract).getYear
 
     val pvatUrls: PVATUrls = PVATUrls(
-      customsFinancialsHomePageUrl = appConfig.customsFinancialsFrontendHomepage,
-      requestStatementsUrl = appConfig.requestedStatements(PostponedVATStatement),
-      pvEmail = PvEmail(appConfig.pvEmailEmailAddress, appConfig.pvEmailEmailAddressHref),
-      viewVatAccountSupportLink = appConfig.viewVatAccountSupportLink,
+      customsFinancialsHomePageUrl = appConfig1.customsFinancialsFrontendHomepage,
+      requestStatementsUrl = appConfig1.requestedStatements(PostponedVATStatement),
+      pvEmail = PvEmail(appConfig1.pvEmailEmailAddress, appConfig1.pvEmailEmailAddressHref),
+      viewVatAccountSupportLink = appConfig1.viewVatAccountSupportLink,
       serviceUnavailableUrl = Some(routes.ServiceUnavailableController.onPageLoad("postponed-vat").url)
     )
   }

--- a/test/controllers/PostponedVatControllerSpec.scala
+++ b/test/controllers/PostponedVatControllerSpec.scala
@@ -48,7 +48,7 @@ class PostponedVatControllerSpec extends SpecBase {
   "show" should {
 
     "display the PostponedVat page with one column(CDS) for statements" in new Setup {
-      appConfig1.historicStatementsEnabled = false
+      appConfigForSetup.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -89,7 +89,7 @@ class PostponedVatControllerSpec extends SpecBase {
     }
 
     "display the PostponedVat page with two columns (CHIEF and CDS) for last 6 months" in new Setup {
-      appConfig1.historicStatementsEnabled = false
+      appConfigForSetup.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -121,7 +121,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "display the PostponedVat page with one column(CDS) " +
       "and Ignore historic CHIEF statements older than 6 months" in new Setup {
-        appConfig1.historicStatementsEnabled = false
+        appConfigForSetup.historicStatementsEnabled = false
 
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -182,7 +182,8 @@ class PostponedVatControllerSpec extends SpecBase {
               hasRequestedStatements = true,
               isCdsOnly = true,
               location = Some(cdsLocation),
-              urls = pvatUrls.copy(serviceUnavailableUrl = Some(appConfig1.historicRequestUrl(PostponedVATStatement)))
+              urls =
+                pvatUrls.copy(serviceUnavailableUrl = Some(appConfigForSetup.historicRequestUrl(PostponedVATStatement)))
             )(messages, mockDateTimeService)
           )(request, messages, appConfig).toString()
 
@@ -203,7 +204,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "not display the immediate previous month statement on PostponedVat page when accessed " +
       "before 20th day of the month and statement is not available" in new Setup {
-        appConfig1.historicStatementsEnabled = false
+        appConfigForSetup.historicStatementsEnabled = false
 
         val currentDate: LocalDate = LocalDate.of(date.getYear, date.getMonthValue, DAY_12)
 
@@ -248,9 +249,9 @@ class PostponedVatControllerSpec extends SpecBase {
       }
 
     "display historic statements Url when feature is enabled" in new Setup {
-      appConfig1.historicStatementsEnabled = true
+      appConfigForSetup.historicStatementsEnabled = true
 
-      val historicRequestUrl: String = appConfig1.historicRequestUrl(PostponedVATStatement)
+      val historicRequestUrl: String = appConfigForSetup.historicRequestUrl(PostponedVATStatement)
       val currentDate: LocalDate     = LocalDate.of(date.getYear, date.getMonthValue, DAY_12)
 
       when(mockDataStoreConnector.getEmail(any)(any))
@@ -311,7 +312,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "when exception occurs in get postponedVAT statements api" in new Setup {
 
-      appConfig1.historicStatementsEnabled = false
+      appConfigForSetup.historicStatementsEnabled = false
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
       when(mockDataStoreConnector.getEmail(any)(any))
@@ -713,7 +714,7 @@ class PostponedVatControllerSpec extends SpecBase {
         )
         .build()
 
-    val appConfig1: AppConfig = instanceOf[AppConfig](app)
+    val appConfigForSetup: AppConfig = instanceOf[AppConfig](app)
 
     val view: postponed_import_vat = instanceOf[postponed_import_vat](app)
 
@@ -724,10 +725,10 @@ class PostponedVatControllerSpec extends SpecBase {
       LocalDate.now().minusMonths(monthValueToSubtract).getYear
 
     val pvatUrls: PVATUrls = PVATUrls(
-      customsFinancialsHomePageUrl = appConfig1.customsFinancialsFrontendHomepage,
-      requestStatementsUrl = appConfig1.requestedStatements(PostponedVATStatement),
-      pvEmail = PvEmail(appConfig1.pvEmailEmailAddress, appConfig1.pvEmailEmailAddressHref),
-      viewVatAccountSupportLink = appConfig1.viewVatAccountSupportLink,
+      customsFinancialsHomePageUrl = appConfigForSetup.customsFinancialsFrontendHomepage,
+      requestStatementsUrl = appConfigForSetup.requestedStatements(PostponedVATStatement),
+      pvEmail = PvEmail(appConfigForSetup.pvEmailEmailAddress, appConfigForSetup.pvEmailEmailAddressHref),
+      viewVatAccountSupportLink = appConfigForSetup.viewVatAccountSupportLink,
       serviceUnavailableUrl = Some(routes.ServiceUnavailableController.onPageLoad("postponed-vat").url)
     )
   }

--- a/test/controllers/PostponedVatControllerSpec.scala
+++ b/test/controllers/PostponedVatControllerSpec.scala
@@ -288,16 +288,17 @@ class PostponedVatControllerSpec extends SpecBase {
 
   "statementsUnavailablePage" should {
     "display the view correctly" in {
+      val app = applicationBuilder().build()
 
-      val view      = instanceOf[postponed_import_vat_not_available](application)
-      val navigator = instanceOf[Navigator](application)
+      val view      = instanceOf[postponed_import_vat_not_available](app)
+      val navigator = instanceOf[Navigator](app)
 
       val serviceUnavailableUrl: String =
         routes.ServiceUnavailableController.onPageLoad(navigator.postponedVatNotAvailablePageId).url
 
-      running(application) {
+      running(app) {
         val request = fakeRequest(GET, routes.PostponedVatController.statementsUnavailablePage().url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe

--- a/test/controllers/PostponedVatControllerSpec.scala
+++ b/test/controllers/PostponedVatControllerSpec.scala
@@ -48,7 +48,7 @@ class PostponedVatControllerSpec extends SpecBase {
   "show" should {
 
     "display the PostponedVat page with one column(CDS) for statements" in new Setup {
-      config.historicStatementsEnabled = false
+      appConfig.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -80,8 +80,8 @@ class PostponedVatControllerSpec extends SpecBase {
             isCdsOnly = true,
             location = Some(cdsLocation),
             urls = pvatUrls
-          )(messages(app), mockDateTimeService)
-        )(request, messages(app), config).toString()
+          )(messages, mockDateTimeService)
+        )(request, messages, appConfig).toString()
 
         contentAsString(result).contains(serviceUnavailableUrl)
         contentAsString(result) should not include "CHIEF statement -"
@@ -89,7 +89,7 @@ class PostponedVatControllerSpec extends SpecBase {
     }
 
     "display the PostponedVat page with two columns (CHIEF and CDS) for last 6 months" in new Setup {
-      config.historicStatementsEnabled = false
+      appConfig.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -121,7 +121,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "display the PostponedVat page with one column(CDS) " +
       "and Ignore historic CHIEF statements older than 6 months" in new Setup {
-        config.historicStatementsEnabled = false
+        appConfig.historicStatementsEnabled = false
 
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
@@ -182,20 +182,20 @@ class PostponedVatControllerSpec extends SpecBase {
               hasRequestedStatements = true,
               isCdsOnly = true,
               location = Some(cdsLocation),
-              urls = pvatUrls.copy(serviceUnavailableUrl = Some(config.historicRequestUrl(PostponedVATStatement)))
-            )(messages(app), mockDateTimeService)
-          )(request, messages(app), config).toString()
+              urls = pvatUrls.copy(serviceUnavailableUrl = Some(appConfig.historicRequestUrl(PostponedVATStatement)))
+            )(messages, mockDateTimeService)
+          )(request, messages, appConfig).toString()
 
           val doc           = Jsoup.parse(contentAsString(result))
           val periodElement = Formatters
-            .dateAsMonthAndYear(date.minusMonths(ONE_MONTH))(messages(app))
+            .dateAsMonthAndYear(date.minusMonths(ONE_MONTH))(messages)
             .replace(singleSpace, hyphen)
             .toLowerCase
 
           doc.getElementById(s"period-$periodElement").children().text() should include(
-            messages(app)(
+            messages(
               "cf.common.not-available",
-              Formatters.dateAsMonth(date.minusMonths(ONE_MONTH))(messages(app))
+              Formatters.dateAsMonth(date.minusMonths(ONE_MONTH))(messages)
             )
           )
         }
@@ -203,7 +203,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "not display the immediate previous month statement on PostponedVat page when accessed " +
       "before 20th day of the month and statement is not available" in new Setup {
-        config.historicStatementsEnabled = false
+        appConfig.historicStatementsEnabled = false
 
         val currentDate: LocalDate = LocalDate.of(date.getYear, date.getMonthValue, DAY_12)
 
@@ -234,12 +234,12 @@ class PostponedVatControllerSpec extends SpecBase {
               isCdsOnly = true,
               location = Some(cdsLocation),
               urls = pvatUrls
-            )(messages(app), mockDateTimeService)
-          )(request, messages(app), config).toString()
+            )(messages, mockDateTimeService)
+          )(request, messages, appConfig).toString()
 
           val doc           = Jsoup.parse(contentAsString(result))
           val periodElement = Formatters
-            .dateAsMonthAndYear(date.minusMonths(ONE_MONTH))(messages(app))
+            .dateAsMonthAndYear(date.minusMonths(ONE_MONTH))(messages)
             .replace(singleSpace, hyphen)
             .toLowerCase
 
@@ -248,9 +248,9 @@ class PostponedVatControllerSpec extends SpecBase {
       }
 
     "display historic statements Url when feature is enabled" in new Setup {
-      config.historicStatementsEnabled = true
+      appConfig.historicStatementsEnabled = true
 
-      val historicRequestUrl: String = config.historicRequestUrl(PostponedVATStatement)
+      val historicRequestUrl: String = appConfig.historicRequestUrl(PostponedVATStatement)
       val currentDate: LocalDate     = LocalDate.of(date.getYear, date.getMonthValue, DAY_12)
 
       when(mockDataStoreConnector.getEmail(any)(any))
@@ -280,8 +280,8 @@ class PostponedVatControllerSpec extends SpecBase {
             isCdsOnly = true,
             location = Some(cdsLocation),
             urls = pvatUrls.copy(serviceUnavailableUrl = Some(historicRequestUrl))
-          )(messages(app), mockDateTimeService)
-        )(request, messages(app), config).toString()
+          )(messages, mockDateTimeService)
+        )(request, messages, appConfig).toString()
       }
     }
   }
@@ -289,21 +289,19 @@ class PostponedVatControllerSpec extends SpecBase {
   "statementsUnavailablePage" should {
     "display the view correctly" in {
 
-      val app       = application().build()
-      val view      = app.injector.instanceOf[postponed_import_vat_not_available]
-      val appConfig = app.injector.instanceOf[AppConfig]
-      val navigator = app.injector.instanceOf[Navigator]
+      val view      = application.injector.instanceOf[postponed_import_vat_not_available]
+      val navigator = application.injector.instanceOf[Navigator]
 
       val serviceUnavailableUrl: String =
         routes.ServiceUnavailableController.onPageLoad(navigator.postponedVatNotAvailablePageId).url
 
-      running(app) {
+      running(application) {
         val request = fakeRequest(GET, routes.PostponedVatController.statementsUnavailablePage().url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe
-          view(EORI_NUMBER, Some(serviceUnavailableUrl))(request, messages(app), appConfig).toString()
+          view(EORI_NUMBER, Some(serviceUnavailableUrl))(request, messages, appConfig).toString()
       }
     }
   }
@@ -312,7 +310,7 @@ class PostponedVatControllerSpec extends SpecBase {
 
     "when exception occurs in get postponedVAT statements api" in new Setup {
 
-      config.historicStatementsEnabled = false
+      appConfig.historicStatementsEnabled = false
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("postponed-vat").url
 
       when(mockDataStoreConnector.getEmail(any)(any))
@@ -703,7 +701,9 @@ class PostponedVatControllerSpec extends SpecBase {
     )
 
     val app: Application =
-      application(Seq(EoriHistory(historicEori, Some(date.minusYears(ONE_YEAR)), Some(date.minusMonths(SIX_MONTHS)))))
+      applicationBuilder(
+        Seq(EoriHistory(historicEori, Some(date.minusYears(ONE_YEAR)), Some(date.minusMonths(SIX_MONTHS))))
+      )
         .overrides(
           inject.bind[FinancialsApiConnector].toInstance(mockFinancialsApiConnector),
           inject.bind[SdesConnector].toInstance(mockSdesConnector),
@@ -713,7 +713,6 @@ class PostponedVatControllerSpec extends SpecBase {
         .build()
 
     val view: postponed_import_vat = app.injector.instanceOf[postponed_import_vat]
-    val config: AppConfig          = app.injector.instanceOf[AppConfig]
 
     private def monthValueOfCurrentDate(monthValueToSubtract: Int): Int =
       LocalDate.now().minusMonths(monthValueToSubtract).getMonthValue
@@ -722,10 +721,10 @@ class PostponedVatControllerSpec extends SpecBase {
       LocalDate.now().minusMonths(monthValueToSubtract).getYear
 
     val pvatUrls: PVATUrls = PVATUrls(
-      customsFinancialsHomePageUrl = config.customsFinancialsFrontendHomepage,
-      requestStatementsUrl = config.requestedStatements(PostponedVATStatement),
-      pvEmail = PvEmail(config.pvEmailEmailAddress, config.pvEmailEmailAddressHref),
-      viewVatAccountSupportLink = config.viewVatAccountSupportLink,
+      customsFinancialsHomePageUrl = appConfig.customsFinancialsFrontendHomepage,
+      requestStatementsUrl = appConfig.requestedStatements(PostponedVATStatement),
+      pvEmail = PvEmail(appConfig.pvEmailEmailAddress, appConfig.pvEmailEmailAddressHref),
+      viewVatAccountSupportLink = appConfig.viewVatAccountSupportLink,
       serviceUnavailableUrl = Some(routes.ServiceUnavailableController.onPageLoad("postponed-vat").url)
     )
   }

--- a/test/controllers/SecuritiesControllerSpec.scala
+++ b/test/controllers/SecuritiesControllerSpec.scala
@@ -140,7 +140,7 @@ class SecuritiesControllerSpec extends SpecBase {
   "statementsUnavailablePage" should {
 
     "render correctly" in {
-      val unavailableView = application.injector.instanceOf[security_statements_not_available]
+      val unavailableView = instanceOf[security_statements_not_available](application)
 
       running(application) {
         val request = fakeRequest(GET, routes.SecuritiesController.statementsUnavailablePage().url)
@@ -169,7 +169,7 @@ class SecuritiesControllerSpec extends SpecBase {
       fakeRequest(GET, routes.SecuritiesController.showSecurityStatements().url)
 
     val result: Future[Result]    = route(app, request).value
-    val view: security_statements = app.injector.instanceOf[security_statements]
+    val view: security_statements = instanceOf[security_statements](app)
 
     val date: LocalDate               = LocalDate.now().withDayOfMonth(DAY_28)
     val someRequestId: Option[String] = Some("statement-request-id")

--- a/test/controllers/SecuritiesControllerSpec.scala
+++ b/test/controllers/SecuritiesControllerSpec.scala
@@ -140,16 +140,14 @@ class SecuritiesControllerSpec extends SpecBase {
   "statementsUnavailablePage" should {
 
     "render correctly" in {
-      val app: Application = application().build()
-      val appConfig        = app.injector.instanceOf[AppConfig]
-      val unavailableView  = app.injector.instanceOf[security_statements_not_available]
+      val unavailableView = application.injector.instanceOf[security_statements_not_available]
 
-      running(app) {
+      running(application) {
         val request = fakeRequest(GET, routes.SecuritiesController.statementsUnavailablePage().url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe OK
-        contentAsString(result) mustBe unavailableView()(request, messages(app), appConfig).toString()
+        contentAsString(result) mustBe unavailableView()(request, messages, appConfig).toString()
       }
     }
   }
@@ -160,7 +158,7 @@ class SecuritiesControllerSpec extends SpecBase {
 
     val eoriHistory: Seq[EoriHistory] = Seq(EoriHistory(EORI_NUMBER, None, None))
 
-    val app: Application = application(eoriHistory)
+    val app: Application = applicationBuilder(eoriHistory)
       .overrides(
         inject.bind[FinancialsApiConnector].toInstance(mockFinancialsApiConnector),
         inject.bind[SdesConnector].toInstance(mockSdesConnector)
@@ -169,8 +167,6 @@ class SecuritiesControllerSpec extends SpecBase {
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] =
       fakeRequest(GET, routes.SecuritiesController.showSecurityStatements().url)
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
 
     val result: Future[Result]    = route(app, request).value
     val view: security_statements = app.injector.instanceOf[security_statements]

--- a/test/controllers/SecuritiesControllerSpec.scala
+++ b/test/controllers/SecuritiesControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import config.AppConfig
 import connectors.{FinancialsApiConnector, SdesConnector}
 import models.FileFormat.{Csv, Pdf}
 import models.FileRole.SecurityStatement
@@ -26,7 +25,6 @@ import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.mustBe
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.i18n.Messages
 import play.api.mvc.{AnyContentAsEmpty, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._

--- a/test/controllers/SecuritiesControllerSpec.scala
+++ b/test/controllers/SecuritiesControllerSpec.scala
@@ -138,11 +138,13 @@ class SecuritiesControllerSpec extends SpecBase {
   "statementsUnavailablePage" should {
 
     "render correctly" in {
-      val unavailableView = instanceOf[security_statements_not_available](application)
+      val app = applicationBuilder().build()
 
-      running(application) {
+      val unavailableView = instanceOf[security_statements_not_available](app)
+
+      running(app) {
         val request = fakeRequest(GET, routes.SecuritiesController.statementsUnavailablePage().url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe unavailableView()(request, messages, appConfig).toString()

--- a/test/controllers/ServiceUnavailableControllerSpec.scala
+++ b/test/controllers/ServiceUnavailableControllerSpec.scala
@@ -68,7 +68,7 @@ class ServiceUnavailableControllerSpec extends SpecBase {
 
   trait Setup {
     val app: Application          = applicationBuilder.build()
-    val view: service_unavailable = app.injector.instanceOf[service_unavailable]
+    val view: service_unavailable = instanceOf[service_unavailable](app)
 
     val navigator: Navigator = new Navigator()
   }

--- a/test/controllers/ServiceUnavailableControllerSpec.scala
+++ b/test/controllers/ServiceUnavailableControllerSpec.scala
@@ -16,13 +16,14 @@
 
 package controllers
 
-import config.AppConfig
 import navigation.Navigator
 import org.scalatest.matchers.must.Matchers.mustBe
+import play.api.Application
 import play.api.http.Status.OK
 import play.api.test.Helpers.{
   GET, contentAsString, defaultAwaitTimeout, route, running, status, writeableOf_AnyContentAsEmpty
 }
+import play.api.test.Helpers._
 import utils.SpecBase
 import views.html.service_unavailable
 
@@ -30,24 +31,20 @@ class ServiceUnavailableControllerSpec extends SpecBase {
 
   "onPageLoad" should {
 
-    val view: service_unavailable = application.injector.instanceOf[service_unavailable]
-
-    val navigator: Navigator = new Navigator()
-
-    "render service unavailable page" in {
-      running(application) {
+    "render service unavailable page" in new Setup {
+      running(app) {
         val request = fakeRequest(GET, routes.ServiceUnavailableController.onPageLoad("id-not-defined").url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe view()(request, messages, appConfig).toString()
       }
     }
 
-    "render service unavailable page for PVAT statements page" in {
-      running(application) {
+    "render service unavailable page for PVAT statements page" in new Setup {
+      running(app) {
         val request = fakeRequest(GET, routes.ServiceUnavailableController.onPageLoad("postponed-vat").url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe OK
 
@@ -56,10 +53,10 @@ class ServiceUnavailableControllerSpec extends SpecBase {
       }
     }
 
-    "render service unavailable page for C79 (Import VAT) statements page" in {
-      running(application) {
+    "render service unavailable page for C79 (Import VAT) statements page" in new Setup {
+      running(app) {
         val request = fakeRequest(GET, routes.ServiceUnavailableController.onPageLoad("import-vat").url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         val backlink = Some(routes.VatController.showVatAccount().url)
 
@@ -67,5 +64,12 @@ class ServiceUnavailableControllerSpec extends SpecBase {
         contentAsString(result) mustBe view(backlink)(request, messages, appConfig).toString()
       }
     }
+  }
+
+  trait Setup {
+    val app: Application          = applicationBuilder.build()
+    val view: service_unavailable = app.injector.instanceOf[service_unavailable]
+
+    val navigator: Navigator = new Navigator()
   }
 }

--- a/test/controllers/ServiceUnavailableControllerSpec.scala
+++ b/test/controllers/ServiceUnavailableControllerSpec.scala
@@ -19,7 +19,6 @@ package controllers
 import config.AppConfig
 import navigation.Navigator
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
 import play.api.http.Status.OK
 import play.api.test.Helpers.{
   GET, contentAsString, defaultAwaitTimeout, route, running, status, writeableOf_AnyContentAsEmpty
@@ -31,46 +30,42 @@ class ServiceUnavailableControllerSpec extends SpecBase {
 
   "onPageLoad" should {
 
-    "render service unavailable page" in new Setup {
-      running(app) {
+    val view: service_unavailable = application.injector.instanceOf[service_unavailable]
+
+    val navigator: Navigator = new Navigator()
+
+    "render service unavailable page" in {
+      running(application) {
         val request = fakeRequest(GET, routes.ServiceUnavailableController.onPageLoad("id-not-defined").url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe OK
-        contentAsString(result) mustBe view()(request, messages(app), appConfig).toString()
+        contentAsString(result) mustBe view()(request, messages, appConfig).toString()
       }
     }
 
-    "render service unavailable page for PVAT statements page" in new Setup {
-      running(app) {
+    "render service unavailable page for PVAT statements page" in {
+      running(application) {
         val request = fakeRequest(GET, routes.ServiceUnavailableController.onPageLoad("postponed-vat").url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe OK
 
         val backlink = Some(routes.PostponedVatController.show(Some("CDS")).url)
-        contentAsString(result) mustBe view(backlink)(request, messages(app), appConfig).toString()
+        contentAsString(result) mustBe view(backlink)(request, messages, appConfig).toString()
       }
     }
 
-    "render service unavailable page for C79 (Import VAT) statements page" in new Setup {
-      running(app) {
+    "render service unavailable page for C79 (Import VAT) statements page" in {
+      running(application) {
         val request = fakeRequest(GET, routes.ServiceUnavailableController.onPageLoad("import-vat").url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         val backlink = Some(routes.VatController.showVatAccount().url)
 
         status(result) mustBe OK
-        contentAsString(result) mustBe view(backlink)(request, messages(app), appConfig).toString()
+        contentAsString(result) mustBe view(backlink)(request, messages, appConfig).toString()
       }
     }
-  }
-
-  trait Setup {
-    val app: Application = application().build()
-
-    val view: service_unavailable = app.injector.instanceOf[service_unavailable]
-    val appConfig: AppConfig      = app.injector.instanceOf[AppConfig]
-    val navigator: Navigator      = app.injector.instanceOf[Navigator]
   }
 }

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -83,6 +83,6 @@ class UnauthorisedControllerSpec extends SpecBase {
       )
       .build()
 
-    val view: not_subscribed_to_cds = app.injector.instanceOf[not_subscribed_to_cds]
+    val view: not_subscribed_to_cds = instanceOf[not_subscribed_to_cds](app)
   }
 }

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -52,7 +52,7 @@ class UnauthorisedControllerSpec extends SpecBase {
         val result  = route(app, request).value
 
         status(result) mustBe OK
-        contentAsString(result) mustBe view()(request, messages(app), appConfig).toString()
+        contentAsString(result) mustBe view()(request, messages, appConfig).toString()
       }
     }
 
@@ -77,13 +77,12 @@ class UnauthorisedControllerSpec extends SpecBase {
 
   trait Setup {
     val mockAuthConnector: AuthConnector = mock[AuthConnector]
-    val app: Application                 = application()
+    val app: Application                 = applicationBuilder()
       .overrides(
         inject.bind[AuthConnector].toInstance(mockAuthConnector)
       )
       .build()
 
     val view: not_subscribed_to_cds = app.injector.instanceOf[not_subscribed_to_cds]
-    val appConfig: AppConfig        = app.injector.instanceOf[AppConfig]
   }
 }

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -494,7 +494,7 @@ class VatControllerSpec extends SpecBase {
 
         if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
           contentAsString(result) mustBe
-            view(viewModel)(request, messages, appConfig).toString()
+            view(viewModel)(request, messages, appConfig1).toString()
         }
       }
     }
@@ -614,15 +614,17 @@ class VatControllerSpec extends SpecBase {
     }
 
     "display historic request url when feature is enabled" in {
-      val view = application.injector.instanceOf[import_vat_not_available]
+      val app = applicationBuilder.build()
+
+      val view = app.injector.instanceOf[import_vat_not_available]
 
       appConfig.historicStatementsEnabled = true
 
       val historicRequestUrl: String = appConfig.historicRequestUrl(C79Certificate)
 
-      running(application) {
+      running(app) {
         val request = fakeRequest(GET, routes.VatController.certificatesUnavailablePage().url)
-        val result  = route(application, request).value
+        val result  = route(app, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe
@@ -649,7 +651,7 @@ class VatControllerSpec extends SpecBase {
       )
       .build()
 
-    var appConfig1: AppConfig = appConfig
+    var appConfig1: AppConfig = app.injector.instanceOf[AppConfig]
 
     val view: import_vat = app.injector.instanceOf[import_vat]
   }

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -49,7 +49,7 @@ class VatControllerSpec extends SpecBase {
   "showVatAccount" should {
     "redirect to certificates unavailable page if getting files fails" in new Setup {
 
-      appConfig1.historicStatementsEnabled = false
+      appConfigForSetup.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad(navigator.importVatPageId).url
 
@@ -90,7 +90,7 @@ class VatControllerSpec extends SpecBase {
 
         status(result) mustBe OK
         contentAsString(result) mustBe
-          view(viewModel)(request, messages, appConfig1).toString()
+          view(viewModel)(request, messages, appConfigForSetup).toString()
       }
     }
 
@@ -109,7 +109,7 @@ class VatControllerSpec extends SpecBase {
 
     "display only last 6 months certs' rows when previous cert files are retrieved in SDES" in new Setup {
 
-      appConfig1.historicStatementsEnabled = false
+      appConfigForSetup.historicStatementsEnabled = false
 
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("import-vat").url
 
@@ -251,7 +251,7 @@ class VatControllerSpec extends SpecBase {
 
         if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
           contentAsString(result) mustBe
-            view(viewModel)(request, messages, appConfig1).toString()
+            view(viewModel)(request, messages, appConfigForSetup).toString()
 
           val doc = Jsoup.parse(contentAsString(result))
 
@@ -305,7 +305,7 @@ class VatControllerSpec extends SpecBase {
             contentAsString(result) mustBe view(viewModel)(
               request,
               messages,
-              appConfig1
+              appConfigForSetup
             ).toString()
 
             val doc = Jsoup.parse(contentAsString(result))
@@ -326,7 +326,7 @@ class VatControllerSpec extends SpecBase {
     "not display the cert row for the immediate previous month when cert files are retrieved " +
       "before 20th of the month and cert is not available for immediate previous month" in new Setup {
 
-        appConfig1.historicStatementsEnabled = false
+        appConfigForSetup.historicStatementsEnabled = false
 
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("import-vat").url
 
@@ -359,7 +359,7 @@ class VatControllerSpec extends SpecBase {
             contentAsString(result) mustBe view(viewModel)(
               request,
               messages,
-              appConfig1
+              appConfigForSetup
             ).toString()
 
             val doc = Jsoup.parse(contentAsString(result))
@@ -382,7 +382,7 @@ class VatControllerSpec extends SpecBase {
     "display all the certs' row when cert files are retrieved before 20th of the month and " +
       "cert is available" in new Setup {
 
-        appConfig1.historicStatementsEnabled = false
+        appConfigForSetup.historicStatementsEnabled = false
 
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("import-vat").url
 
@@ -428,7 +428,7 @@ class VatControllerSpec extends SpecBase {
 
           if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
             contentAsString(result) mustBe
-              view(viewModel)(request, messages, appConfig1).toString()
+              view(viewModel)(request, messages, appConfigForSetup).toString()
 
             val doc = Jsoup.parse(contentAsString(result))
 
@@ -449,8 +449,8 @@ class VatControllerSpec extends SpecBase {
 
     "display historic statements Url when feature is enabled" in new Setup {
 
-      appConfig1.historicStatementsEnabled = true
-      val historicRequestUrl: String = appConfig1.historicRequestUrl(C79Certificate)
+      appConfigForSetup.historicStatementsEnabled = true
+      val historicRequestUrl: String = appConfigForSetup.historicRequestUrl(C79Certificate)
 
       val vatCertificateFile: VatCertificateFile = VatCertificateFile(
         STAT_FILE_NAME_04,
@@ -494,7 +494,7 @@ class VatControllerSpec extends SpecBase {
 
         if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
           contentAsString(result) mustBe
-            view(viewModel)(request, messages, appConfig1).toString()
+            view(viewModel)(request, messages, appConfigForSetup).toString()
         }
       }
     }
@@ -502,9 +502,9 @@ class VatControllerSpec extends SpecBase {
     "display requested statements Url when regular and " +
       "requested statements are present in the same period" in new Setup {
 
-        appConfig1.historicStatementsEnabled = true
+        appConfigForSetup.historicStatementsEnabled = true
 
-        val historicRequestUrl: String    = appConfig1.historicRequestUrl(C79Certificate)
+        val historicRequestUrl: String    = appConfigForSetup.historicRequestUrl(C79Certificate)
         val someRequestId: Option[String] = Some("statement-request-id")
 
         val vatCertificateFile: VatCertificateFile = VatCertificateFile(
@@ -581,7 +581,7 @@ class VatControllerSpec extends SpecBase {
 
           if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
             contentAsString(result) mustBe
-              view(viewModel)(request, messages, appConfig1).toString()
+              view(viewModel)(request, messages, appConfigForSetup).toString()
           }
 
           val doc = Jsoup.parse(contentAsString(result))
@@ -652,7 +652,7 @@ class VatControllerSpec extends SpecBase {
       )
       .build()
 
-    var appConfig1: AppConfig = instanceOf[AppConfig](app)
+    var appConfigForSetup: AppConfig = instanceOf[AppConfig](app)
 
     val view: import_vat = instanceOf[import_vat](app)
   }

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -594,11 +594,11 @@ class VatControllerSpec extends SpecBase {
   "certificatesUnavailablePage" should {
 
     "render correctly" in {
-      val view = application.injector.instanceOf[import_vat_not_available]
+      val view = instanceOf[import_vat_not_available](application)
 
       appConfig.historicStatementsEnabled = false
 
-      val navigator = application.injector.instanceOf[Navigator]
+      val navigator = instanceOf[Navigator](application)
 
       val serviceUnavailableUrl: String =
         routes.ServiceUnavailableController.onPageLoad(navigator.importVatNotAvailablePageId).url
@@ -636,9 +636,10 @@ class VatControllerSpec extends SpecBase {
   trait Setup {
     val mockFinancialsApiConnector: FinancialsApiConnector = mock[FinancialsApiConnector]
     val mockSdesConnector: SdesConnector                   = mock[SdesConnector]
-    val eoriHistory: Seq[EoriHistory]                      = Seq(EoriHistory(EORI_NUMBER, None, None))
-    val date: LocalDate                                    = LocalDate.now().withDayOfMonth(DAY_28)
-    val navigator                                          = new Navigator()
+
+    val eoriHistory: Seq[EoriHistory] = Seq(EoriHistory(EORI_NUMBER, None, None))
+    val date: LocalDate               = LocalDate.now().withDayOfMonth(DAY_28)
+    val navigator                     = new Navigator()
 
     when(mockFinancialsApiConnector.deleteNotification(any, any)(any))
       .thenReturn(Future.successful(true))
@@ -651,8 +652,8 @@ class VatControllerSpec extends SpecBase {
       )
       .build()
 
-    var appConfig1: AppConfig = app.injector.instanceOf[AppConfig]
+    var appConfig1: AppConfig = instanceOf[AppConfig](app)
 
-    val view: import_vat = app.injector.instanceOf[import_vat]
+    val view: import_vat = instanceOf[import_vat](app)
   }
 }

--- a/test/controllers/VatControllerSpec.scala
+++ b/test/controllers/VatControllerSpec.scala
@@ -49,9 +49,8 @@ class VatControllerSpec extends SpecBase {
   "showVatAccount" should {
     "redirect to certificates unavailable page if getting files fails" in new Setup {
 
-      appConfig.historicStatementsEnabled = false
+      appConfig1.historicStatementsEnabled = false
 
-      implicit val config: AppConfig    = appConfig
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad(navigator.importVatPageId).url
 
       val vatCertificateFile: VatCertificateFile = VatCertificateFile(
@@ -91,7 +90,7 @@ class VatControllerSpec extends SpecBase {
 
         status(result) mustBe OK
         contentAsString(result) mustBe
-          view(viewModel)(request, msgs, appConfig).toString()
+          view(viewModel)(request, messages, appConfig1).toString()
       }
     }
 
@@ -110,9 +109,8 @@ class VatControllerSpec extends SpecBase {
 
     "display only last 6 months certs' rows when previous cert files are retrieved in SDES" in new Setup {
 
-      appConfig.historicStatementsEnabled = false
+      appConfig1.historicStatementsEnabled = false
 
-      implicit val config: AppConfig    = appConfig
       val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("import-vat").url
 
       val vatCertificateFile1: VatCertificateFile = VatCertificateFile(
@@ -253,7 +251,7 @@ class VatControllerSpec extends SpecBase {
 
         if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
           contentAsString(result) mustBe
-            view(viewModel)(request, msgs, appConfig).toString()
+            view(viewModel)(request, messages, appConfig1).toString()
 
           val doc = Jsoup.parse(contentAsString(result))
 
@@ -275,8 +273,6 @@ class VatControllerSpec extends SpecBase {
 
     "display the cert unavailable text for the relevant month when cert files are retrieved " +
       "after 19th of the month and cert is not available" in new Setup {
-
-        implicit val config: AppConfig = appConfig
 
         val currentCertificates: Seq[VatCertificatesByMonth] = Seq(
           VatCertificatesByMonth(date.minusMonths(ONE_MONTH), Seq()),
@@ -308,8 +304,8 @@ class VatControllerSpec extends SpecBase {
           if (!DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
             contentAsString(result) mustBe view(viewModel)(
               request,
-              msgs,
-              appConfig
+              messages,
+              appConfig1
             ).toString()
 
             val doc = Jsoup.parse(contentAsString(result))
@@ -318,7 +314,7 @@ class VatControllerSpec extends SpecBase {
 
             doc.getElementById("statements-list-0-row-0").children().text() should
               include(
-                msgs(
+                messages(
                   "cf.account.vat.statements.unavailable",
                   Formatters.dateAsMonth(date.minusMonths(ONE_MONTH))
                 )
@@ -330,8 +326,8 @@ class VatControllerSpec extends SpecBase {
     "not display the cert row for the immediate previous month when cert files are retrieved " +
       "before 20th of the month and cert is not available for immediate previous month" in new Setup {
 
-        appConfig.historicStatementsEnabled = false
-        implicit val config: AppConfig    = appConfig
+        appConfig1.historicStatementsEnabled = false
+
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("import-vat").url
 
         val currentCertificates: Seq[VatCertificatesByMonth] = Seq(
@@ -362,8 +358,8 @@ class VatControllerSpec extends SpecBase {
           if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
             contentAsString(result) mustBe view(viewModel)(
               request,
-              msgs,
-              appConfig
+              messages,
+              appConfig1
             ).toString()
 
             val doc = Jsoup.parse(contentAsString(result))
@@ -375,7 +371,7 @@ class VatControllerSpec extends SpecBase {
             Option(doc.getElementById("statements-list-0-row-3")) should not be empty
             Option(doc.getElementById("statements-list-0-row-4")) should not be empty
 
-            doc.getElementById("statements-list-0-row-0").children().text() should not include msgs(
+            doc.getElementById("statements-list-0-row-0").children().text() should not include messages(
               "cf.account.vat.statements.unavailable",
               Formatters.dateAsMonth(date.minusMonths(ONE_MONTH))
             )
@@ -386,8 +382,8 @@ class VatControllerSpec extends SpecBase {
     "display all the certs' row when cert files are retrieved before 20th of the month and " +
       "cert is available" in new Setup {
 
-        appConfig.historicStatementsEnabled = false
-        implicit val config: AppConfig    = appConfig
+        appConfig1.historicStatementsEnabled = false
+
         val serviceUnavailableUrl: String = routes.ServiceUnavailableController.onPageLoad("import-vat").url
 
         val vatCertificateFile: VatCertificateFile = VatCertificateFile(
@@ -432,7 +428,7 @@ class VatControllerSpec extends SpecBase {
 
           if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
             contentAsString(result) mustBe
-              view(viewModel)(request, msgs, appConfig).toString()
+              view(viewModel)(request, messages, appConfig1).toString()
 
             val doc = Jsoup.parse(contentAsString(result))
 
@@ -443,7 +439,7 @@ class VatControllerSpec extends SpecBase {
             Option(doc.getElementById("statements-list-0-row-4")) should not be empty
             Option(doc.getElementById("statements-list-0-row-5")) should not be empty
 
-            doc.getElementById("statements-list-0-row-0").children().text() should not include msgs(
+            doc.getElementById("statements-list-0-row-0").children().text() should not include messages(
               "cf.account.vat.statements.unavailable",
               Formatters.dateAsMonth(date.minusMonths(ONE_MONTH))
             )
@@ -453,9 +449,8 @@ class VatControllerSpec extends SpecBase {
 
     "display historic statements Url when feature is enabled" in new Setup {
 
-      appConfig.historicStatementsEnabled = true
-      val historicRequestUrl: String = appConfig.historicRequestUrl(C79Certificate)
-      implicit val config: AppConfig = appConfig
+      appConfig1.historicStatementsEnabled = true
+      val historicRequestUrl: String = appConfig1.historicRequestUrl(C79Certificate)
 
       val vatCertificateFile: VatCertificateFile = VatCertificateFile(
         STAT_FILE_NAME_04,
@@ -499,7 +494,7 @@ class VatControllerSpec extends SpecBase {
 
         if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
           contentAsString(result) mustBe
-            view(viewModel)(request, msgs, appConfig).toString()
+            view(viewModel)(request, messages, appConfig).toString()
         }
       }
     }
@@ -507,10 +502,9 @@ class VatControllerSpec extends SpecBase {
     "display requested statements Url when regular and " +
       "requested statements are present in the same period" in new Setup {
 
-        appConfig.historicStatementsEnabled = true
+        appConfig1.historicStatementsEnabled = true
 
-        implicit val config: AppConfig    = appConfig
-        val historicRequestUrl: String    = appConfig.historicRequestUrl(C79Certificate)
+        val historicRequestUrl: String    = appConfig1.historicRequestUrl(C79Certificate)
         val someRequestId: Option[String] = Some("statement-request-id")
 
         val vatCertificateFile: VatCertificateFile = VatCertificateFile(
@@ -587,7 +581,7 @@ class VatControllerSpec extends SpecBase {
 
           if (DateUtils.isDayBefore20ThDayOfTheMonth(LocalDate.now())) {
             contentAsString(result) mustBe
-              view(viewModel)(request, msgs, appConfig).toString()
+              view(viewModel)(request, messages, appConfig1).toString()
           }
 
           val doc = Jsoup.parse(contentAsString(result))
@@ -600,43 +594,39 @@ class VatControllerSpec extends SpecBase {
   "certificatesUnavailablePage" should {
 
     "render correctly" in {
-      val app       = application().build()
-      val view      = app.injector.instanceOf[import_vat_not_available]
-      val appConfig = app.injector.instanceOf[AppConfig]
+      val view = application.injector.instanceOf[import_vat_not_available]
 
       appConfig.historicStatementsEnabled = false
 
-      val navigator = app.injector.instanceOf[Navigator]
+      val navigator = application.injector.instanceOf[Navigator]
 
       val serviceUnavailableUrl: String =
         routes.ServiceUnavailableController.onPageLoad(navigator.importVatNotAvailablePageId).url
 
-      running(app) {
+      running(application) {
         val request = fakeRequest(GET, routes.VatController.certificatesUnavailablePage().url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe
-          view(Some(serviceUnavailableUrl))(request, messages(app), appConfig).toString()
+          view(Some(serviceUnavailableUrl))(request, messages, appConfig).toString()
       }
     }
 
     "display historic request url when feature is enabled" in {
-      val app       = application().build()
-      val view      = app.injector.instanceOf[import_vat_not_available]
-      val appConfig = app.injector.instanceOf[AppConfig]
+      val view = application.injector.instanceOf[import_vat_not_available]
 
       appConfig.historicStatementsEnabled = true
 
       val historicRequestUrl: String = appConfig.historicRequestUrl(C79Certificate)
 
-      running(app) {
+      running(application) {
         val request = fakeRequest(GET, routes.VatController.certificatesUnavailablePage().url)
-        val result  = route(app, request).value
+        val result  = route(application, request).value
 
         status(result) mustBe OK
         contentAsString(result) mustBe
-          view(Some(historicRequestUrl))(request, messages(app), appConfig).toString()
+          view(Some(historicRequestUrl))(request, messages, appConfig).toString()
       }
     }
   }
@@ -651,7 +641,7 @@ class VatControllerSpec extends SpecBase {
     when(mockFinancialsApiConnector.deleteNotification(any, any)(any))
       .thenReturn(Future.successful(true))
 
-    val app: Application = application(eoriHistory)
+    val app: Application = applicationBuilder(eoriHistory)
       .overrides(
         inject.bind[FinancialsApiConnector].toInstance(mockFinancialsApiConnector),
         inject.bind[SdesConnector].toInstance(mockSdesConnector),
@@ -659,8 +649,8 @@ class VatControllerSpec extends SpecBase {
       )
       .build()
 
-    var appConfig: AppConfig    = app.injector.instanceOf[AppConfig]
-    val view: import_vat        = app.injector.instanceOf[import_vat]
-    implicit val msgs: Messages = messages(app)
+    var appConfig1: AppConfig = appConfig
+
+    val view: import_vat = app.injector.instanceOf[import_vat]
   }
 }

--- a/test/models/PostponedVatStatementGroupSpec.scala
+++ b/test/models/PostponedVatStatementGroupSpec.scala
@@ -18,21 +18,18 @@ package models
 
 import org.scalatest.matchers.must.Matchers.mustBe
 import org.mockito.Mockito.when
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.{Application, inject}
 import services.DateTimeService
 import utils.CommonTestData.*
 import utils.SpecBase
 
 import java.time.*
 
-class PostponedVatStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
-  import Setup.*
+class PostponedVatStatementGroupSpec extends SpecBase {
 
   "isPreviousMonthAndAfter19Th" should {
 
     "return true if statement date is of previous month and is accessed on or after " +
-      "19th day of the current month" in {
+      "19th day of the current month" in new Setup {
         val dateOfPreviousMonth: LocalDate = date.minusMonths(ONE_MONTH).withDayOfMonth(DAY_20)
         val currentDate: LocalDate         = LocalDate.of(YEAR_2023, MONTH_10, DAY_20)
 
@@ -45,7 +42,7 @@ class PostponedVatStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
       }
 
     "return false if statement date is of previous month and is accessed on or before " +
-      "19th day of the current month" in {
+      "19th day of the current month" in new Setup {
         val dateOfPreviousMonth: LocalDate = date.minusMonths(ONE_MONTH).withDayOfMonth(DAY_10)
 
         when(mockDateTimeService.systemDateTime())
@@ -57,7 +54,7 @@ class PostponedVatStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
         ).isPreviousMonthAndAfter19Th mustBe false
       }
 
-    "return true if statement date is not from the previous month" in {
+    "return true if statement date is not from the previous month" in new Setup {
       val dateOfCurrentMonth: LocalDate = date.withDayOfMonth(DAY_16)
 
       when(mockDateTimeService.systemDateTime())
@@ -70,9 +67,9 @@ class PostponedVatStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
     }
 
     "return true if statement date is not from the previous month and accessed " +
-      "before 19th day of current date " in {
+      "before 19th day of current date " in new Setup {
 
-        val isCurrentDayBefore20 = LocalDate.now.getDayOfMonth < DAY_20
+        val isCurrentDayBefore20: Boolean = LocalDate.now.getDayOfMonth < DAY_20
 
         if (isCurrentDayBefore20) when(mockDateTimeService.systemDateTime()).thenReturn(date.atStartOfDay())
 
@@ -87,14 +84,8 @@ class PostponedVatStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
       }
   }
 
-  override def fakeApplication(): Application = applicationBuilder()
-    .overrides(
-      inject.bind[DateTimeService].toInstance(mockDateTimeService)
-    )
-    .build()
-
-  object Setup {
-    val mockDateTimeService: DateTimeService = mock[DateTimeService]
+  trait Setup {
     val date: LocalDate                      = LocalDate.of(YEAR_2023, MONTH_10, DAY_1)
+    val mockDateTimeService: DateTimeService = mock[DateTimeService]
   }
 }

--- a/test/models/PostponedVatStatementGroupSpec.scala
+++ b/test/models/PostponedVatStatementGroupSpec.scala
@@ -18,19 +18,21 @@ package models
 
 import org.scalatest.matchers.must.Matchers.mustBe
 import org.mockito.Mockito.when
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.{Application, inject}
 import services.DateTimeService
-import utils.CommonTestData._
+import utils.CommonTestData.*
 import utils.SpecBase
 
-import java.time._
+import java.time.*
 
-class PostponedVatStatementGroupSpec extends SpecBase {
+class PostponedVatStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
+  import Setup.*
 
   "isPreviousMonthAndAfter19Th" should {
 
     "return true if statement date is of previous month and is accessed on or after " +
-      "19th day of the current month" in new Setup {
+      "19th day of the current month" in {
         val dateOfPreviousMonth: LocalDate = date.minusMonths(ONE_MONTH).withDayOfMonth(DAY_20)
         val currentDate: LocalDate         = LocalDate.of(YEAR_2023, MONTH_10, DAY_20)
 
@@ -43,7 +45,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
       }
 
     "return false if statement date is of previous month and is accessed on or before " +
-      "19th day of the current month" in new Setup {
+      "19th day of the current month" in {
         val dateOfPreviousMonth: LocalDate = date.minusMonths(ONE_MONTH).withDayOfMonth(DAY_10)
 
         when(mockDateTimeService.systemDateTime())
@@ -55,7 +57,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
         ).isPreviousMonthAndAfter19Th mustBe false
       }
 
-    "return true if statement date is not from the previous month" in new Setup {
+    "return true if statement date is not from the previous month" in {
       val dateOfCurrentMonth: LocalDate = date.withDayOfMonth(DAY_16)
 
       when(mockDateTimeService.systemDateTime())
@@ -68,9 +70,9 @@ class PostponedVatStatementGroupSpec extends SpecBase {
     }
 
     "return true if statement date is not from the previous month and accessed " +
-      "before 19th day of current date " in new Setup {
+      "before 19th day of current date " in {
 
-        private val isCurrentDayBefore20 = LocalDate.now.getDayOfMonth < DAY_20
+        val isCurrentDayBefore20 = LocalDate.now.getDayOfMonth < DAY_20
 
         if (isCurrentDayBefore20) when(mockDateTimeService.systemDateTime()).thenReturn(date.atStartOfDay())
 
@@ -85,14 +87,14 @@ class PostponedVatStatementGroupSpec extends SpecBase {
       }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder()
+    .overrides(
+      inject.bind[DateTimeService].toInstance(mockDateTimeService)
+    )
+    .build()
+
+  object Setup {
     val mockDateTimeService: DateTimeService = mock[DateTimeService]
     val date: LocalDate                      = LocalDate.of(YEAR_2023, MONTH_10, DAY_1)
-
-    val app: Application = applicationBuilder()
-      .overrides(
-        inject.bind[DateTimeService].toInstance(mockDateTimeService)
-      )
-      .build()
   }
 }

--- a/test/models/PostponedVatStatementGroupSpec.scala
+++ b/test/models/PostponedVatStatementGroupSpec.scala
@@ -37,7 +37,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
         when(mockDateTimeService.systemDateTime()).thenReturn(currentDate.atStartOfDay())
 
         PostponedVatStatementGroup(dateOfPreviousMonth, Seq())(
-          messages(app),
+          messages,
           mockDateTimeService
         ).isPreviousMonthAndAfter19Th mustBe true
       }
@@ -50,7 +50,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
           .thenReturn(date.atStartOfDay())
 
         PostponedVatStatementGroup(dateOfPreviousMonth, Seq())(
-          messages(app),
+          messages,
           mockDateTimeService
         ).isPreviousMonthAndAfter19Th mustBe false
       }
@@ -62,7 +62,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
         .thenReturn(date.atStartOfDay())
 
       PostponedVatStatementGroup(dateOfCurrentMonth, Seq())(
-        messages(app),
+        messages,
         mockDateTimeService
       ).isPreviousMonthAndAfter19Th mustBe true
     }
@@ -78,7 +78,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
 
         if (isCurrentDayBefore20) {
           PostponedVatStatementGroup(dateOfCurrentMonthAndBefore20ThDay, Seq())(
-            messages(app),
+            messages,
             mockDateTimeService
           ).isPreviousMonthAndAfter19Th mustBe true
         }
@@ -89,7 +89,7 @@ class PostponedVatStatementGroupSpec extends SpecBase {
     val mockDateTimeService: DateTimeService = mock[DateTimeService]
     val date: LocalDate                      = LocalDate.of(YEAR_2023, MONTH_10, DAY_1)
 
-    val app: Application = application()
+    val app: Application = applicationBuilder()
       .overrides(
         inject.bind[DateTimeService].toInstance(mockDateTimeService)
       )

--- a/test/services/DateTimeServiceSpec.scala
+++ b/test/services/DateTimeServiceSpec.scala
@@ -28,7 +28,7 @@ class DateTimeServiceSpec extends SpecBase {
   "return the fixed date if fixedDateTime is enabled" in {
 
     val app     = applicationBuilder().configure("features.fixed-system-time" -> true).build()
-    val service = app.injector.instanceOf[DateTimeService]
+    val service = instanceOf[DateTimeService](app)
 
     running(app) {
       service.systemDateTime() mustBe

--- a/test/services/DateTimeServiceSpec.scala
+++ b/test/services/DateTimeServiceSpec.scala
@@ -27,7 +27,7 @@ class DateTimeServiceSpec extends SpecBase {
 
   "return the fixed date if fixedDateTime is enabled" in {
 
-    val app     = application().configure("features.fixed-system-time" -> true).build()
+    val app     = applicationBuilder().configure("features.fixed-system-time" -> true).build()
     val service = app.injector.instanceOf[DateTimeService]
 
     running(app) {

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -36,6 +36,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.stubPlayBodyParsers
 import utils.Utils.emptyString
 
+import scala.reflect.ClassTag
+
 trait SpecBase
     extends AnyWordSpecLike
     with MockitoSugar
@@ -78,6 +80,8 @@ trait SpecBase
   implicit lazy val messages: Messages = application.injector.instanceOf[MessagesApi].preferred(fakeRequest())
 
   implicit lazy val appConfig: AppConfig = application.injector.instanceOf[AppConfig]
+
+  def instanceOf[T: ClassTag](app: Application): T = app.injector.instanceOf[T]
 }
 
 class FakeMetrics extends MetricRegistry {

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -19,6 +19,7 @@ package utils
 import actions.{IdentifierAction, PvatIdentifierAction}
 import org.apache.pekko.stream.testkit.NoMaterializer
 import com.codahale.metrics.MetricRegistry
+import config.AppConfig
 import models.EoriHistory
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.OptionValues
@@ -53,10 +54,7 @@ class SpecBase
       .asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
       .withHeaders(newHeaders = "X-Session-Id" -> "someSessionId")
 
-  def messages(app: Application): Messages =
-    app.injector.instanceOf[MessagesApi].preferred(fakeRequest(emptyString, emptyString))
-
-  def application(allEoriHistory: Seq[EoriHistory] = Seq.empty): GuiceApplicationBuilder =
+  def applicationBuilder(allEoriHistory: Seq[EoriHistory] = Seq.empty): GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .overrides(
         bind[IdentifierAction]
@@ -70,4 +68,11 @@ class SpecBase
         "auditing.enabled"               -> "false",
         "metrics.enabled"                -> "false"
       )
+
+  val application: Application = applicationBuilder().build()
+
+  implicit lazy val messages: Messages =
+    application.injector.instanceOf[MessagesApi].preferred(fakeRequest(emptyString, emptyString))
+
+  implicit lazy val appConfig: AppConfig = application.injector.instanceOf[AppConfig]
 }

--- a/test/viewmodels/ImportVatViewModelSpec.scala
+++ b/test/viewmodels/ImportVatViewModelSpec.scala
@@ -21,7 +21,6 @@ import models.{EoriHistory, VatCertificateFile, VatCertificatesByMonth, VatCerti
 import models.metadata.VatCertificateFileMetadata
 import models.FileRole.C79Certificate
 import org.scalatest.Assertion
-import play.api.Application
 import play.api.i18n.Messages
 import utils.CommonTestData.{
   DAY_28, EORI_NUMBER, FIVE_MONTHS, FOUR_MONTHS, ONE_MONTH, SIX_MONTHS, SIZE_111L, STAT_FILE_NAME_04, THREE_MONTHS,
@@ -92,10 +91,10 @@ class ImportVatViewModelSpec extends SpecBase {
   }
 
   private def shouldContainCorrectTitle(viewModel: ImportVatViewModel)(implicit msgs: Messages): Assertion =
-    viewModel.title mustBe Some(msgs("cf.account.vat.title"))
+    viewModel.title mustBe Some(messages("cf.account.vat.title"))
 
   private def shouldContainCorrectBackLink(viewModel: ImportVatViewModel)(implicit config: AppConfig): Assertion =
-    viewModel.backLink mustBe Some(config.customsFinancialsFrontendHomepage)
+    viewModel.backLink mustBe Some(appConfig.customsFinancialsFrontendHomepage)
 
   private def shouldContainCorrectHeading(viewModel: ImportVatViewModel)(implicit msgs: Messages): Assertion =
     viewModel.heading mustBe h1Component(
@@ -194,10 +193,10 @@ class ImportVatViewModelSpec extends SpecBase {
           tabLink = Some(
             new HmrcNewTabLink().apply(
               NewTabLink(
-                language = Some(msgs.lang.toString),
+                language = Some(messages.lang.toString),
                 classList = Some("govuk-link"),
                 href = Some(appConfig.viewVatAccountSupportLink),
-                text = msgs("cf.account.vat.support.link")
+                text = messages("cf.account.vat.support.link")
               )
             )
           )
@@ -262,16 +261,13 @@ class ImportVatViewModelSpec extends SpecBase {
       )
     } else {
       ddComponent(
-        content = Html(msgs("cf.account.vat.statements.unavailable", statementsOfOneMonth.formattedMonth)),
+        content = Html(messages("cf.account.vat.statements.unavailable", statementsOfOneMonth.formattedMonth)),
         classes = Some("govuk-summary-list__actions")
       )
     }
 
   trait Setup {
     val date: LocalDate = LocalDate.now().withDayOfMonth(DAY_28)
-
-    val app: Application        = application().build()
-    implicit val msgs: Messages = messages(app)
 
     val vatCertificateFile1: VatCertificateFile = VatCertificateFile(
       STAT_FILE_NAME_04,
@@ -372,8 +368,6 @@ class ImportVatViewModelSpec extends SpecBase {
     )
 
     val serviceUnavailableUrl: String = URL_TEST
-
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
 
     val viewModel: ImportVatViewModel = ImportVatViewModel(certificatesForAllEoris, Some(serviceUnavailableUrl))
 

--- a/test/viewmodels/PostponedVatViewModelSpec.scala
+++ b/test/viewmodels/PostponedVatViewModelSpec.scala
@@ -40,13 +40,11 @@ import java.time.{LocalDate, LocalDateTime}
 
 class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "CurrentStatementRow.apply" should {
 
     "produce CurrentStatementRow with correct contents" when {
 
-      "isCdsOnly is true and PostponedVatStatementGroup has statements" in {
+      "isCdsOnly is true and PostponedVatStatementGroup has statements" in new Setup {
 
         val isCdsOnly = true
 
@@ -86,7 +84,7 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
         CurrentStatementRow(pvatStatementGroup, dutyPaymentMethodSource, isCdsOnly) mustBe expectedResult
       }
 
-      "isCdsOnly is false and PostponedVatStatementGroup has statements" in {
+      "isCdsOnly is false and PostponedVatStatementGroup has statements" in new Setup {
         val isCdsOnly = false
 
         val pvatStatementGroup: PostponedVatStatementGroup =
@@ -126,7 +124,7 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
       }
 
       "PostponedVatStatementGroup has no statements, startDate is of the previous month (after 19th) " +
-        "and isCdsOnly is true" in {
+        "and isCdsOnly is true" in new Setup {
 
           val isCdsOnly = true
 
@@ -155,7 +153,7 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
         }
 
       "PostponedVatStatementGroup has no statements, startDate is of the previous month (after 19th) " +
-        "and isCdsOnly is false" in {
+        "and isCdsOnly is false" in new Setup {
 
           val isCdsOnly = false
 
@@ -198,7 +196,7 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
 
     "produce PostponedVatViewModel with correct contents" when {
 
-      "PostponedVatStatementFile records are present" in {
+      "PostponedVatStatementFile records are present" in new Setup {
 
         when(mockDateTimeService.systemDateTime()).thenReturn(date)
 
@@ -243,7 +241,7 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
         actualPVatModel.helpAndSupportGuidance mustBe expectedHelpAndSupportGuidance
       }
 
-      "there are no PostponedVatStatementFile records" in {
+      "there are no PostponedVatStatementFile records" in new Setup {
 
         when(mockDateTimeService.systemDateTime()).thenReturn(date)
 
@@ -302,7 +300,7 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val certificateFiles: Seq[PostponedVatStatementFile] = Seq(
       PostponedVatStatementFile(
         STAT_FILE_NAME_04,

--- a/test/viewmodels/PostponedVatViewModelSpec.scala
+++ b/test/viewmodels/PostponedVatViewModelSpec.scala
@@ -26,23 +26,27 @@ import org.mockito.Mockito.when
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import services.DateTimeService
-import utils.CommonTestData._
+import utils.CommonTestData.*
 import utils.SpecBase
 import utils.Utils.{emptyString, h1Component, h2Component, linkComponent, pComponent, period}
 import views.helpers.Formatters
-import views.html.components._
+import views.html.components.*
 import views.html.postponed_vat.{collapsible_statement_group, current_statement_row, download_link_pvat_statement}
 import common.GuidanceRow
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 
 import java.time.{LocalDate, LocalDateTime}
 
-class PostponedVatViewModelSpec extends SpecBase {
+class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "CurrentStatementRow.apply" should {
 
     "produce CurrentStatementRow with correct contents" when {
 
-      "isCdsOnly is true and PostponedVatStatementGroup has statements" in new Setup {
+      "isCdsOnly is true and PostponedVatStatementGroup has statements" in {
 
         val isCdsOnly = true
 
@@ -82,7 +86,7 @@ class PostponedVatViewModelSpec extends SpecBase {
         CurrentStatementRow(pvatStatementGroup, dutyPaymentMethodSource, isCdsOnly) mustBe expectedResult
       }
 
-      "isCdsOnly is false and PostponedVatStatementGroup has statements" in new Setup {
+      "isCdsOnly is false and PostponedVatStatementGroup has statements" in {
         val isCdsOnly = false
 
         val pvatStatementGroup: PostponedVatStatementGroup =
@@ -122,7 +126,7 @@ class PostponedVatViewModelSpec extends SpecBase {
       }
 
       "PostponedVatStatementGroup has no statements, startDate is of the previous month (after 19th) " +
-        "and isCdsOnly is true" in new Setup {
+        "and isCdsOnly is true" in {
 
           val isCdsOnly = true
 
@@ -151,7 +155,7 @@ class PostponedVatViewModelSpec extends SpecBase {
         }
 
       "PostponedVatStatementGroup has no statements, startDate is of the previous month (after 19th) " +
-        "and isCdsOnly is false" in new Setup {
+        "and isCdsOnly is false" in {
 
           val isCdsOnly = false
 
@@ -194,7 +198,7 @@ class PostponedVatViewModelSpec extends SpecBase {
 
     "produce PostponedVatViewModel with correct contents" when {
 
-      "PostponedVatStatementFile records are present" in new Setup {
+      "PostponedVatStatementFile records are present" in {
 
         when(mockDateTimeService.systemDateTime()).thenReturn(date)
 
@@ -239,7 +243,7 @@ class PostponedVatViewModelSpec extends SpecBase {
         actualPVatModel.helpAndSupportGuidance mustBe expectedHelpAndSupportGuidance
       }
 
-      "there are no PostponedVatStatementFile records" in new Setup {
+      "there are no PostponedVatStatementFile records" in {
 
         when(mockDateTimeService.systemDateTime()).thenReturn(date)
 
@@ -296,7 +300,9 @@ class PostponedVatViewModelSpec extends SpecBase {
     expectedCurrentRows
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val certificateFiles: Seq[PostponedVatStatementFile] = Seq(
       PostponedVatStatementFile(
         STAT_FILE_NAME_04,
@@ -478,7 +484,7 @@ class PostponedVatViewModelSpec extends SpecBase {
       preLinkMessageKey: String,
       postLinkMessageKey: String
     )(implicit msgs: Messages): HtmlFormat.Appendable =
-      instanceOf[requestedStatements](application)
+      instanceOf[requestedStatements](app)
         .apply(url, linkMessageKey, preLinkMessageKey, postLinkMessageKey)
   }
 }

--- a/test/viewmodels/PostponedVatViewModelSpec.scala
+++ b/test/viewmodels/PostponedVatViewModelSpec.scala
@@ -478,8 +478,7 @@ class PostponedVatViewModelSpec extends SpecBase {
       preLinkMessageKey: String,
       postLinkMessageKey: String
     )(implicit msgs: Messages): HtmlFormat.Appendable =
-      application.injector
-        .instanceOf[requestedStatements]
+      instanceOf[requestedStatements](application)
         .apply(url, linkMessageKey, preLinkMessageKey, postLinkMessageKey)
   }
 }

--- a/test/viewmodels/PostponedVatViewModelSpec.scala
+++ b/test/viewmodels/PostponedVatViewModelSpec.scala
@@ -23,7 +23,6 @@ import models.metadata.PostponedVatStatementFileMetadata
 import models.{PostponedVatStatementFile, PostponedVatStatementGroup}
 import org.scalatest.matchers.must.Matchers.mustBe
 import org.mockito.Mockito.when
-import play.api.Application
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import services.DateTimeService
@@ -74,7 +73,7 @@ class PostponedVatViewModelSpec extends SpecBase {
 
         val expectedResult: CurrentStatementRow = CurrentStatementRow(
           pvatStatementGroup.periodId,
-          msgs(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
+          messages(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
           cdsDDRow = None,
           chiefDDRow = None,
           collapsibleStatementGroupRows = Seq(collapStatGroupRowForSourceCDS, collapStatGroupRowForSourceCHIEF)
@@ -113,7 +112,7 @@ class PostponedVatViewModelSpec extends SpecBase {
 
         val expectedResult: CurrentStatementRow = CurrentStatementRow(
           pvatStatementGroup.periodId,
-          msgs(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
+          messages(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
           cdsDDRow = None,
           chiefDDRow = None,
           collapsibleStatementGroupRows = Seq(collapStatGroupRowForSourceCDS, collapStatGroupRowForSourceCHIEF)
@@ -133,8 +132,8 @@ class PostponedVatViewModelSpec extends SpecBase {
             PostponedVatStatementGroup(dateOfPreviousMonthAndAfter19th, Seq())
 
           val cdsDDRow: DDRow = DDRow(
-            msgs("cf.common.not-available"),
-            msgs(
+            messages("cf.common.not-available"),
+            messages(
               "cf.common.not-available-screen-reader-cds",
               Formatters.dateAsMonthAndYear(pvatStatementGroup.startDate)
             )
@@ -142,7 +141,7 @@ class PostponedVatViewModelSpec extends SpecBase {
 
           val expectedResult: CurrentStatementRow = CurrentStatementRow(
             pvatStatementGroup.periodId,
-            msgs(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
+            messages(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
             cdsDDRow = Some(cdsDDRow),
             chiefDDRow = None,
             collapsibleStatementGroupRows = Seq()
@@ -162,16 +161,16 @@ class PostponedVatViewModelSpec extends SpecBase {
             PostponedVatStatementGroup(dateOfPreviousMonthAndAfter19th, Seq())
 
           val cdsDDRow: DDRow = DDRow(
-            msgs("cf.common.not-available"),
-            msgs(
+            messages("cf.common.not-available"),
+            messages(
               "cf.common.not-available-screen-reader-cds",
               Formatters.dateAsMonthAndYear(pvatStatementGroup.startDate)
             )
           )
 
           val chiefDDRow: DDRow = DDRow(
-            msgs("cf.common.not-available"),
-            msgs(
+            messages("cf.common.not-available"),
+            messages(
               "cf.common.not-available-screen-reader-chief",
               Formatters.dateAsMonthAndYear(pvatStatementGroup.startDate)
             )
@@ -179,7 +178,7 @@ class PostponedVatViewModelSpec extends SpecBase {
 
           val expectedResult: CurrentStatementRow = CurrentStatementRow(
             pvatStatementGroup.periodId,
-            msgs(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
+            messages(Formatters.dateAsMonthAndYear(dateOfPreviousMonthAndAfter19th)),
             cdsDDRow = Some(cdsDDRow),
             chiefDDRow = Some(chiefDDRow),
             collapsibleStatementGroupRows = Seq()
@@ -213,7 +212,7 @@ class PostponedVatViewModelSpec extends SpecBase {
           )
         )
 
-        actualPVatModel.pageTitle mustBe msgs("cf.account.pvat.title")
+        actualPVatModel.pageTitle mustBe messages("cf.account.pvat.title")
         actualPVatModel.backLink mustBe Some(customsFinancialsHomePageUrl)
 
         actualPVatModel.pageH1Heading mustBe expectedHeading
@@ -258,7 +257,7 @@ class PostponedVatViewModelSpec extends SpecBase {
           )
         )
 
-        actualPVatModel.pageTitle mustBe msgs("cf.account.pvat.title")
+        actualPVatModel.pageTitle mustBe messages("cf.account.pvat.title")
         actualPVatModel.backLink mustBe Some(customsFinancialsHomePageUrl)
 
         actualPVatModel.pageH1Heading mustBe expectedHeading
@@ -324,9 +323,6 @@ class PostponedVatViewModelSpec extends SpecBase {
     val dutyPaymentMethodSource: Seq[String] = Seq(CDS, CHIEF)
     val linkInner                            = new linkInner()
     val downloadLinkPvatStatement            = new download_link_pvat_statement(linkInner)
-
-    val app: Application        = application().build()
-    implicit val msgs: Messages = messages(app)
 
     implicit val mockDateTimeService: DateTimeService = mock[DateTimeService]
 
@@ -466,7 +462,7 @@ class PostponedVatViewModelSpec extends SpecBase {
       ),
       link = Some(
         linkComponent.apply(
-          msgs("cf.account.pvat.support.link"),
+          messages("cf.account.pvat.support.link"),
           location = viewVatAccountSupportLink,
           preLinkMessage = Some("cf.account.pvat.support.message"),
           postLinkMessage = Some(period),
@@ -482,6 +478,8 @@ class PostponedVatViewModelSpec extends SpecBase {
       preLinkMessageKey: String,
       postLinkMessageKey: String
     )(implicit msgs: Messages): HtmlFormat.Appendable =
-      app.injector.instanceOf[requestedStatements].apply(url, linkMessageKey, preLinkMessageKey, postLinkMessageKey)
+      application.injector
+        .instanceOf[requestedStatements]
+        .apply(url, linkMessageKey, preLinkMessageKey, postLinkMessageKey)
   }
 }

--- a/test/viewmodels/SecurityStatementsViewModelSpec.scala
+++ b/test/viewmodels/SecurityStatementsViewModelSpec.scala
@@ -21,7 +21,6 @@ import models.FileRole.SecurityStatement
 import models.{EoriHistory, SecurityStatementsByPeriod, SecurityStatementsForEori}
 import org.scalatest.matchers.must.Matchers.mustBe
 import org.mockito.Mockito.when
-import play.api.Application
 import play.api.i18n.Messages
 import play.twirl.api.{Html, HtmlFormat}
 import utils.CommonTestData.{DAY_28, MONTH_11, YEAR_2019}
@@ -40,7 +39,7 @@ class SecurityStatementsViewModelSpec extends SpecBase {
     "produce SecurityStatementsViewModel with correct contents" when {
 
       "statementsForAllEoris has requested and current statements" in new Setup {
-        result.pageTitle mustBe Some(message("cf.security-statements.title"))
+        result.pageTitle mustBe Some(messages("cf.security-statements.title"))
         result.backLink mustBe Some(appConfig.customsFinancialsFrontendHomepage)
         result.header mustBe expectedHeader
         result.requestedStatementNotification mustBe expectedRequestedNotification
@@ -54,8 +53,6 @@ class SecurityStatementsViewModelSpec extends SpecBase {
 
   trait Setup {
     implicit val appConfig: AppConfig = mock[AppConfig]
-    val app: Application              = application().build()
-    implicit val message: Messages    = messages(app)
 
     val date: LocalDate = LocalDate.of(YEAR_2019, MONTH_11, DAY_28)
 

--- a/test/views/NotSubscribedToCdsSpec.scala
+++ b/test/views/NotSubscribedToCdsSpec.scala
@@ -16,23 +16,24 @@
 
 package views
 
-import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.mustBe
-
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
 import views.html.not_subscribed_to_cds
 
-class NotSubscribedToCdsSpec extends SpecBase {
+class NotSubscribedToCdsSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "NotSubscribedToCds view" should {
 
-    "display correct title and guidance" in new Setup {
+    "display correct title and guidance" in {
+      import Setup.*
+
       view.title() mustBe
         s"${messages("cf.not-subscribed-to-cds.detail.title")} - ${messages("service.name")} - GOV.UK"
 
@@ -54,12 +55,14 @@ class NotSubscribedToCdsSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val deskProLinkText = "Is this page not working properly? (opens in new tab)"
     val cdsSubscribeUrl = "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(instanceOf[not_subscribed_to_cds](application).apply().body)
+    val view: Document = Jsoup.parse(instanceOf[not_subscribed_to_cds](app).apply().body)
   }
 }

--- a/test/views/NotSubscribedToCdsSpec.scala
+++ b/test/views/NotSubscribedToCdsSpec.scala
@@ -60,6 +60,6 @@ class NotSubscribedToCdsSpec extends SpecBase {
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(application.injector.instanceOf[not_subscribed_to_cds].apply().body)
+    val view: Document = Jsoup.parse(instanceOf[not_subscribed_to_cds](application).apply().body)
   }
 }

--- a/test/views/NotSubscribedToCdsSpec.scala
+++ b/test/views/NotSubscribedToCdsSpec.scala
@@ -21,7 +21,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -34,21 +34,21 @@ class NotSubscribedToCdsSpec extends SpecBase {
 
     "display correct title and guidance" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.not-subscribed-to-cds.detail.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.not-subscribed-to-cds.detail.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementsByTag("h1").html() mustBe messages(app)("cf.not-subscribed-to-cds.detail.heading")
+      view.getElementsByTag("h1").html() mustBe messages("cf.not-subscribed-to-cds.detail.heading")
 
       view.getElementById("already-subscribed-heading").html() mustBe
-        messages(app)("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds")
+        messages("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds")
       view.getElementById("subscribed-to-cds-heading").html() mustBe
-        messages(app)("cf.not-subscribed-to-cds.details.subscribe-to-cds")
+        messages("cf.not-subscribed-to-cds.details.subscribe-to-cds")
 
       val pElements: Elements = view.getElementsByTag("p")
       pElements.get(1).html() mustBe
-        messages(app)("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds-guidance-text")
+        messages("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds-guidance-text")
 
       view.html().contains(cdsSubscribeUrl)
-      view.html().contains(messages(app)("cf.not-subscribed-to-cds.details.subscribe-to-cds-link-text"))
+      view.html().contains(messages("cf.not-subscribed-to-cds.details.subscribe-to-cds-link-text"))
 
       view.html().contains(deskProLinkText)
     }
@@ -58,12 +58,8 @@ class NotSubscribedToCdsSpec extends SpecBase {
     val deskProLinkText = "Is this page not working properly? (opens in new tab)"
     val cdsSubscribeUrl = "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
 
-    val app: Application = application().build()
-
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[not_subscribed_to_cds].apply().body)
+    val view: Document = Jsoup.parse(application.injector.instanceOf[not_subscribed_to_cds].apply().body)
   }
 }

--- a/test/views/NotSubscribedToCdsSpec.scala
+++ b/test/views/NotSubscribedToCdsSpec.scala
@@ -31,8 +31,7 @@ class NotSubscribedToCdsSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "NotSubscribedToCds view" should {
 
-    "display correct title and guidance" in {
-      import Setup.*
+    "display correct title and guidance" in new Setup {
 
       view.title() mustBe
         s"${messages("cf.not-subscribed-to-cds.detail.title")} - ${messages("service.name")} - GOV.UK"
@@ -57,7 +56,7 @@ class NotSubscribedToCdsSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val deskProLinkText = "Is this page not working properly? (opens in new tab)"
     val cdsSubscribeUrl = "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
 

--- a/test/views/PostponedImportVatNotAvailableSpec.scala
+++ b/test/views/PostponedImportVatNotAvailableSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -33,39 +33,39 @@ class PostponedImportVatNotAvailableSpec extends SpecBase {
 
     "display correct title and guidance" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.account.pvat.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.account.pvat.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementById("no-statements").text() mustBe messages(app)("cf.security-statements.unavailable")
+      view.getElementById("no-statements").text() mustBe messages("cf.security-statements.unavailable")
 
       view.getElementById("missing-documents-guidance-heading").text() mustBe
-        messages(app)("cf.account.pvat.older-statements.heading")
+        messages("cf.account.pvat.older-statements.heading")
 
       view.getElementById("pvat.support.message.heading").text() mustBe
-        messages(app)("cf.account.pvat.support.heading")
+        messages("cf.account.pvat.support.heading")
 
       view.getElementById("pvat.support.heading").text() must not be empty
 
       view.html().contains(tradeAndExciseEnquiryLink)
       view.getElementById("chief-guidance-heading").html() mustBe
-        messages(app)("cf.account.vat.chief.heading")
-      view.html().contains(messages(app)("cf.account.pvat.older-statements.description.3"))
+        messages("cf.account.vat.chief.heading")
+      view.html().contains(messages("cf.account.pvat.older-statements.description.3"))
       view.html().contains(serviceUnavailableUrl)
     }
   }
 
   trait Setup {
-    val app: Application              = application().build()
     val serviceUnavailableUrl: String = "service_unavailable_url"
     val eori                          = "test_eori"
     val hmrcDomainUrl                 = "https://www.gov.uk/government/organisations/hm-revenue-customs"
     val tradeAndExciseEnquiryLink     = s"$hmrcDomainUrl/contact/customs-international-trade-and-excise-enquiries"
 
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document = Jsoup.parse(
-      app.injector.instanceOf[postponed_import_vat_not_available].apply(eori, Option(serviceUnavailableUrl)).body
+      application.injector
+        .instanceOf[postponed_import_vat_not_available]
+        .apply(eori, Option(serviceUnavailableUrl))
+        .body
     )
   }
 }

--- a/test/views/PostponedImportVatNotAvailableSpec.scala
+++ b/test/views/PostponedImportVatNotAvailableSpec.scala
@@ -31,9 +31,7 @@ class PostponedImportVatNotAvailableSpec extends SpecBase with GuiceOneAppPerSui
 
   "PostponedImportVatNotAvailable view" should {
 
-    "display correct title and guidance" in {
-      import Setup.*
-
+    "display correct title and guidance" in new Setup {
       view.title() mustBe
         s"${messages("cf.account.pvat.title")} - ${messages("service.name")} - GOV.UK"
 
@@ -57,7 +55,7 @@ class PostponedImportVatNotAvailableSpec extends SpecBase with GuiceOneAppPerSui
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val serviceUnavailableUrl: String = "service_unavailable_url"
     val eori                          = "test_eori"
     val hmrcDomainUrl                 = "https://www.gov.uk/government/organisations/hm-revenue-customs"

--- a/test/views/PostponedImportVatNotAvailableSpec.scala
+++ b/test/views/PostponedImportVatNotAvailableSpec.scala
@@ -20,18 +20,20 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
 import views.html.postponed_import_vat_not_available
 
-class PostponedImportVatNotAvailableSpec extends SpecBase {
+class PostponedImportVatNotAvailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "PostponedImportVatNotAvailable view" should {
 
-    "display correct title and guidance" in new Setup {
+    "display correct title and guidance" in {
+      import Setup.*
+
       view.title() mustBe
         s"${messages("cf.account.pvat.title")} - ${messages("service.name")} - GOV.UK"
 
@@ -53,7 +55,9 @@ class PostponedImportVatNotAvailableSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val serviceUnavailableUrl: String = "service_unavailable_url"
     val eori                          = "test_eori"
     val hmrcDomainUrl                 = "https://www.gov.uk/government/organisations/hm-revenue-customs"
@@ -62,7 +66,7 @@ class PostponedImportVatNotAvailableSpec extends SpecBase {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document = Jsoup.parse(
-      instanceOf[postponed_import_vat_not_available](application)
+      instanceOf[postponed_import_vat_not_available](app)
         .apply(eori, Option(serviceUnavailableUrl))
         .body
     )

--- a/test/views/PostponedImportVatNotAvailableSpec.scala
+++ b/test/views/PostponedImportVatNotAvailableSpec.scala
@@ -62,8 +62,7 @@ class PostponedImportVatNotAvailableSpec extends SpecBase {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document = Jsoup.parse(
-      application.injector
-        .instanceOf[postponed_import_vat_not_available]
+      instanceOf[postponed_import_vat_not_available](application)
         .apply(eori, Option(serviceUnavailableUrl))
         .body
     )

--- a/test/views/PostponedImportVatSpec.scala
+++ b/test/views/PostponedImportVatSpec.scala
@@ -62,19 +62,17 @@ class PostponedImportVatSpec extends SpecBase {
           .body
       )
 
-      running(app) {
-        view.title() mustBe s"${messages(app)("cf.account.pvat.title")} - ${messages(app)("service.name")} - GOV.UK"
-        view.getElementById("main-content").html()         must not contain "h2"
-        view.html().contains("cf.account.vat.available.statement-text")
-        view.getElementsByTag("dl").size()                 must be > 0
-        view.getElementsByTag("dt").size()                 must be > 0
-        view.getElementsByTag("dd").size()                 must be > 0
-        view.getElementById("pvat.support.heading").html() must not be empty
-        view.getElementById("pvat.support.message").html() must not be empty
-        view.html().contains(serviceUnavailbleUrl)
-        view.getElementById("chief-guidance-heading").html() mustBe
-          messages(app)("cf.account.vat.chief.heading")
-      }
+      view.title() mustBe s"${messages("cf.account.pvat.title")} - ${messages("service.name")} - GOV.UK"
+      view.getElementById("main-content").html()         must not contain "h2"
+      view.html().contains("cf.account.vat.available.statement-text")
+      view.getElementsByTag("dl").size()                 must be > 0
+      view.getElementsByTag("dt").size()                 must be > 0
+      view.getElementsByTag("dd").size()                 must be > 0
+      view.getElementById("pvat.support.heading").html() must not be empty
+      view.getElementById("pvat.support.message").html() must not be empty
+      view.html().contains(serviceUnavailableUrl)
+      view.getElementById("chief-guidance-heading").html() mustBe
+        messages("cf.account.vat.chief.heading")
     }
 
     "not display CHIEF doc column when there are no CHIEF doc" in new Setup {
@@ -97,11 +95,9 @@ class PostponedImportVatSpec extends SpecBase {
 
       val expectedSize = 7
 
-      running(app) {
-        view.html().contains(messages(app)("cf.account.pvat.download-link", "CDS", "PDF", "111KB"))
-        view.html()                        must not contain messages(app)("cf.account.pvat.download-link", "CHIEF", "PDF", "111KB")
-        view.getElementsByTag("dd").size() must be(expectedSize)
-      }
+      view.html().contains(messages("cf.account.pvat.download-link", "CDS", "PDF", "111KB"))
+      view.html()                        must not contain messages("cf.account.pvat.download-link", "CHIEF", "PDF", "111KB")
+      view.getElementsByTag("dd").size() must be(expectedSize)
     }
 
     "display 'not available' messages correctly when no statements are present " +
@@ -124,14 +120,13 @@ class PostponedImportVatSpec extends SpecBase {
             .body
         )
 
-        running(app) {
-          val cdsNotAvailableMessage = view.select("dd").text()
-          cdsNotAvailableMessage must include(messages(app)("cf.common.not-available"))
-        }
+        val cdsNotAvailableMessage: String = view.select("dd").text()
+        cdsNotAvailableMessage must include(messages("cf.common.not-available"))
       }
 
     "display grouped certificates by EORI and format correctly" in new Setup {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
+
       val view: Document = Jsoup.parse(
         app.injector
           .instanceOf[postponed_import_vat]
@@ -149,10 +144,8 @@ class PostponedImportVatSpec extends SpecBase {
 
       val expectedSize = 13
 
-      running(app) {
-        view.select("dd.govuk-summary-list__actions").size() mustBe expectedSize
-        view.html() must include(messages(app)("cf.account.pvat.aria.amended-download-link"))
-      }
+      view.select("dd.govuk-summary-list__actions").size() mustBe expectedSize
+      view.html() must include(messages("cf.account.pvat.aria.amended-download-link"))
     }
 
     "handle missing files and display messages appropriately" in new Setup {
@@ -173,16 +166,14 @@ class PostponedImportVatSpec extends SpecBase {
           .body
       )
 
-      running(app) {
-        view.html() must include(messages(app)("cf.common.not-available"))
-      }
+      view.html() must include(messages("cf.common.not-available"))
     }
   }
 
   trait Setup {
     val date: LocalDate = LocalDate.now()
 
-    val serviceUnavailbleUrl: String = "service_unavailable_url"
+    val serviceUnavailableUrl: String = "service_unavailable_url"
 
     val postVatStatMetaData1: PostponedVatStatementFileMetadata = PostponedVatStatementFileMetadata(
       date.getYear,
@@ -309,14 +300,12 @@ class PostponedImportVatSpec extends SpecBase {
 
     implicit val mockDateTimeService: DateTimeService = mock[DateTimeService]
 
-    val app: Application = application()
+    val app: Application = applicationBuilder()
       .overrides(
         inject.bind[DateTimeService].toInstance(mockDateTimeService)
       )
       .build()
 
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val pvatUrls: PVATUrls = PVATUrls(
@@ -324,7 +313,7 @@ class PostponedImportVatSpec extends SpecBase {
       requestStatementsUrl = appConfig.requestedStatements(PostponedVATStatement),
       pvEmail = PvEmail(appConfig.pvEmailEmailAddress, appConfig.pvEmailEmailAddressHref),
       viewVatAccountSupportLink = appConfig.viewVatAccountSupportLink,
-      serviceUnavailableUrl = Some(serviceUnavailbleUrl)
+      serviceUnavailableUrl = Some(serviceUnavailableUrl)
     )
   }
 }

--- a/test/views/PostponedImportVatSpec.scala
+++ b/test/views/PostponedImportVatSpec.scala
@@ -48,8 +48,7 @@ class PostponedImportVatSpec extends SpecBase {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
-        app.injector
-          .instanceOf[postponed_import_vat]
+        instanceOf[postponed_import_vat](app)
           .apply(
             PostponedVatViewModel(
               postponedVatStatementFiles,
@@ -79,8 +78,7 @@ class PostponedImportVatSpec extends SpecBase {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
-        app.injector
-          .instanceOf[postponed_import_vat]
+        instanceOf[postponed_import_vat](app)
           .apply(
             PostponedVatViewModel(
               postponedVatStatementFiles,
@@ -106,8 +104,7 @@ class PostponedImportVatSpec extends SpecBase {
           .thenReturn(LocalDateTime.now().withDayOfMonth(DAY_19).minusMonths(ONE_MONTH))
 
         val view: Document = Jsoup.parse(
-          app.injector
-            .instanceOf[postponed_import_vat]
+          instanceOf[postponed_import_vat](app)
             .apply(
               PostponedVatViewModel(
                 postponedVatStatementFiles,
@@ -128,8 +125,7 @@ class PostponedImportVatSpec extends SpecBase {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
-        app.injector
-          .instanceOf[postponed_import_vat]
+        instanceOf[postponed_import_vat](app)
           .apply(
             PostponedVatViewModel(
               postponedVatStatementFiles,
@@ -152,8 +148,7 @@ class PostponedImportVatSpec extends SpecBase {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
-        app.injector
-          .instanceOf[postponed_import_vat]
+        instanceOf[postponed_import_vat](app)
           .apply(
             PostponedVatViewModel(
               Seq.empty,

--- a/test/views/PostponedImportVatSpec.scala
+++ b/test/views/PostponedImportVatSpec.scala
@@ -40,11 +40,11 @@ import java.time.{LocalDate, LocalDateTime}
 
 class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
+  implicit val mockDateTimeService: DateTimeService = mock[DateTimeService]
 
   "PostponedImportVatView" should {
 
-    "display the correct title and guidance" in {
+    "display the correct title and guidance" in new Setup {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
@@ -74,7 +74,7 @@ class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
         messages("cf.account.vat.chief.heading")
     }
 
-    "not display CHIEF doc column when there are no CHIEF doc" in {
+    "not display CHIEF doc column when there are no CHIEF doc" in new Setup {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
@@ -99,7 +99,7 @@ class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
     }
 
     "display 'not available' messages correctly when no statements are present " +
-      "and it is after the 19th of the previous month" in {
+      "and it is after the 19th of the previous month" in new Setup {
         when(mockDateTimeService.systemDateTime())
           .thenReturn(LocalDateTime.now().withDayOfMonth(DAY_19).minusMonths(ONE_MONTH))
 
@@ -121,7 +121,7 @@ class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
         cdsNotAvailableMessage must include(messages("cf.common.not-available"))
       }
 
-    "display grouped certificates by EORI and format correctly" in {
+    "display grouped certificates by EORI and format correctly" in new Setup {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
@@ -144,7 +144,7 @@ class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
       view.html() must include(messages("cf.account.pvat.aria.amended-download-link"))
     }
 
-    "handle missing files and display messages appropriately" in {
+    "handle missing files and display messages appropriately" in new Setup {
       when(mockDateTimeService.systemDateTime()).thenReturn(LocalDateTime.now())
 
       val view: Document = Jsoup.parse(
@@ -172,7 +172,7 @@ class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
       )
       .build()
 
-  object Setup {
+  trait Setup {
     val date: LocalDate = LocalDate.now()
 
     val serviceUnavailableUrl: String = "service_unavailable_url"
@@ -300,7 +300,6 @@ class PostponedImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
       PostponedVatStatementFile(STAT_FILE_NAME_02, DOWNLOAD_URL_00, SIZE_111L, postVatStatMetaData12, EORI_NUMBER)
     )
 
-    implicit val mockDateTimeService: DateTimeService         = mock[DateTimeService]
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val pvatUrls: PVATUrls = PVATUrls(

--- a/test/views/ServiceUnavailableSpec.scala
+++ b/test/views/ServiceUnavailableSpec.scala
@@ -32,8 +32,7 @@ class ServiceUnavailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "ServiceUnavailable view" should {
 
-    "display correct title and guidance" in {
-      import Setup.*
+    "display correct title and guidance" in new Setup {
 
       view.title() mustBe
         s"${messages("cf.service-unavailable.title")} - ${messages("service.name")} - GOV.UK"
@@ -52,7 +51,7 @@ class ServiceUnavailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val backLinkUrl         = "test_url"
     val deskProLink: String = "http://localhost:9250" +
       "/contact/report-technical-problem?newTab=true&amp;service=CDS%20FinancialsreferrerUrl=test_Path"

--- a/test/views/ServiceUnavailableSpec.scala
+++ b/test/views/ServiceUnavailableSpec.scala
@@ -22,7 +22,6 @@ import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase

--- a/test/views/ServiceUnavailableSpec.scala
+++ b/test/views/ServiceUnavailableSpec.scala
@@ -20,18 +20,21 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
 import views.html.service_unavailable
 
-class ServiceUnavailableSpec extends SpecBase {
+class ServiceUnavailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "ServiceUnavailable view" should {
 
-    "display correct title and guidance" in new Setup {
+    "display correct title and guidance" in {
+      import Setup.*
+
       view.title() mustBe
         s"${messages("cf.service-unavailable.title")} - ${messages("service.name")} - GOV.UK"
       view.getElementById("service-unavailable.heading").html() mustBe
@@ -47,7 +50,9 @@ class ServiceUnavailableSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val backLinkUrl         = "test_url"
     val deskProLink: String = "http://localhost:9250" +
       "/contact/report-technical-problem?newTab=true&amp;service=CDS%20FinancialsreferrerUrl=test_Path"
@@ -55,6 +60,6 @@ class ServiceUnavailableSpec extends SpecBase {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(instanceOf[service_unavailable](application).apply(Option(backLinkUrl)).body)
+      Jsoup.parse(instanceOf[service_unavailable](app).apply(Option(backLinkUrl)).body)
   }
 }

--- a/test/views/ServiceUnavailableSpec.scala
+++ b/test/views/ServiceUnavailableSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -33,16 +33,16 @@ class ServiceUnavailableSpec extends SpecBase {
 
     "display correct title and guidance" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.service-unavailable.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.service-unavailable.title")} - ${messages("service.name")} - GOV.UK"
       view.getElementById("service-unavailable.heading").html() mustBe
-        messages(app)("cf.service-unavailable.heading")
+        messages("cf.service-unavailable.heading")
 
       view.getElementById("older-statement-guidance-text").text() must not be empty
       view.getElementById("older-statement-guidance-text").text() mustBe
-        s"${messages(app)("cf.service-unavailable.description.1")} ${messages(app)("cf.service-unavailable.description.2")}"
+        s"${messages("cf.service-unavailable.description.1")} ${messages("cf.service-unavailable.description.2")}"
 
       view.html().contains(backLinkUrl)
-      view.html().contains(messages(app)("cf.service-unavailable.description.3"))
+      view.html().contains(messages("cf.service-unavailable.description.3"))
       view.html().contains(deskProLink)
     }
   }
@@ -52,12 +52,9 @@ class ServiceUnavailableSpec extends SpecBase {
     val deskProLink: String = "http://localhost:9250" +
       "/contact/report-technical-problem?newTab=true&amp;service=CDS%20FinancialsreferrerUrl=test_Path"
 
-    val app: Application = application().build()
-
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[service_unavailable].apply(Option(backLinkUrl)).body)
+    val view: Document =
+      Jsoup.parse(application.injector.instanceOf[service_unavailable].apply(Option(backLinkUrl)).body)
   }
 }

--- a/test/views/ServiceUnavailableSpec.scala
+++ b/test/views/ServiceUnavailableSpec.scala
@@ -55,6 +55,6 @@ class ServiceUnavailableSpec extends SpecBase {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(application.injector.instanceOf[service_unavailable].apply(Option(backLinkUrl)).body)
+      Jsoup.parse(instanceOf[service_unavailable](application).apply(Option(backLinkUrl)).body)
   }
 }

--- a/test/views/components/DivSpec.scala
+++ b/test/views/components/DivSpec.scala
@@ -28,13 +28,11 @@ import play.api.Application
 
 class DivSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "div component" should {
 
     "display correct contents" when {
 
-      "only content has been provided" in {
+      "only content has been provided" in new Setup {
         val div: Elements = divComponent.select("div")
 
         div.text() mustBe contentText
@@ -42,7 +40,7 @@ class DivSpec extends SpecBase with GuiceOneAppPerSuite {
         div.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in {
+      "class has been provided along with content" in new Setup {
         val div: Elements = divComponentWithClass.select("div")
 
         div.text() mustBe contentText
@@ -50,7 +48,7 @@ class DivSpec extends SpecBase with GuiceOneAppPerSuite {
         div.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in {
+      "id has been provided along with content" in new Setup {
         val div: Elements = divComponentWithId.select("div")
 
         div.text() mustBe contentText
@@ -58,7 +56,7 @@ class DivSpec extends SpecBase with GuiceOneAppPerSuite {
         div.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in {
+      "both class and id have been provided along with content" in new Setup {
         val div: Elements = divComponentWithClassAndId.select("div")
 
         div.text() mustBe contentText
@@ -70,7 +68,7 @@ class DivSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val contentText   = "some content"
     val content: Html = Html(contentText)
     val testClass     = "test-class"

--- a/test/views/components/DivSpec.scala
+++ b/test/views/components/DivSpec.scala
@@ -20,18 +20,21 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.twirl.api.Html
 import utils.SpecBase
 import views.html.components.div
+import play.api.Application
 
-class DivSpec extends SpecBase {
+class DivSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "div component" should {
 
     "display correct contents" when {
 
-      "only content has been provided" in new Setup {
+      "only content has been provided" in {
         val div: Elements = divComponent.select("div")
 
         div.text() mustBe contentText
@@ -39,7 +42,7 @@ class DivSpec extends SpecBase {
         div.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in new Setup {
+      "class has been provided along with content" in {
         val div: Elements = divComponentWithClass.select("div")
 
         div.text() mustBe contentText
@@ -47,7 +50,7 @@ class DivSpec extends SpecBase {
         div.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in new Setup {
+      "id has been provided along with content" in {
         val div: Elements = divComponentWithId.select("div")
 
         div.text() mustBe contentText
@@ -55,7 +58,7 @@ class DivSpec extends SpecBase {
         div.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in new Setup {
+      "both class and id have been provided along with content" in {
         val div: Elements = divComponentWithClassAndId.select("div")
 
         div.text() mustBe contentText
@@ -65,13 +68,15 @@ class DivSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val contentText   = "some content"
     val content: Html = Html(contentText)
     val testClass     = "test-class"
     val testId        = "test-id"
 
-    val instanceOfDiv: div = instanceOf[div](application)
+    val instanceOfDiv: div = instanceOf[div](app)
 
     val divComponent: Document               = Jsoup.parse(instanceOfDiv(content).body)
     val divComponentWithClass: Document      = Jsoup.parse(instanceOfDiv(content, classes = Some(testClass)).body)

--- a/test/views/components/DivSpec.scala
+++ b/test/views/components/DivSpec.scala
@@ -71,7 +71,7 @@ class DivSpec extends SpecBase {
     val testClass     = "test-class"
     val testId        = "test-id"
 
-    val instanceOfDiv: div = application.injector.instanceOf[div]
+    val instanceOfDiv: div = instanceOf[div](application)
 
     val divComponent: Document               = Jsoup.parse(instanceOfDiv(content).body)
     val divComponentWithClass: Document      = Jsoup.parse(instanceOfDiv(content, classes = Some(testClass)).body)

--- a/test/views/components/DivSpec.scala
+++ b/test/views/components/DivSpec.scala
@@ -20,7 +20,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
 import play.api.i18n.Messages
 import play.twirl.api.Html
 import utils.SpecBase
@@ -72,10 +71,7 @@ class DivSpec extends SpecBase {
     val testClass     = "test-class"
     val testId        = "test-id"
 
-    val app: Application           = application().build()
-    implicit val message: Messages = messages(app)
-
-    val instanceOfDiv: div = app.injector.instanceOf[div]
+    val instanceOfDiv: div = application.injector.instanceOf[div]
 
     val divComponent: Document               = Jsoup.parse(instanceOfDiv(content).body)
     val divComponentWithClass: Document      = Jsoup.parse(instanceOfDiv(content, classes = Some(testClass)).body)

--- a/test/views/components/H1Spec.scala
+++ b/test/views/components/H1Spec.scala
@@ -20,18 +20,21 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.h1
 
-class H1Spec extends SpecBase {
+class H1Spec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "h1 component" should {
 
     "display correct contents" when {
 
-      "only message key has been provided" in new Setup {
+      "only message key has been provided" in {
         h1Component.text() mustBe messages(msgKey)
 
         val h1: Elements = h1Component.select("h1")
@@ -42,7 +45,7 @@ class H1Spec extends SpecBase {
         h1.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with message key" in new Setup {
+      "class has been provided along with message key" in {
         h1ComponentWithClass.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithClass.select("h1")
@@ -50,7 +53,7 @@ class H1Spec extends SpecBase {
         h1.first().classNames() must contain(classes)
       }
 
-      "id has been provided along with message key" in new Setup {
+      "id has been provided along with message key" in {
         h1ComponentWithId.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithId.select("h1")
@@ -58,7 +61,7 @@ class H1Spec extends SpecBase {
         h1.first().attr("id") mustBe id
       }
 
-      "classes and id have been provided along with message key" in new Setup {
+      "classes and id have been provided along with message key" in {
         h1ComponentWithClassAndId.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithClassAndId.select("h1")
@@ -69,13 +72,15 @@ class H1Spec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val msgKey       = "messageKey"
     val defaultClass = "govuk-heading-l"
     val classes      = "custom-class"
     val id           = "custom-id"
 
-    val instanceOfH1: h1 = instanceOf[h1](application)
+    val instanceOfH1: h1 = instanceOf[h1](app)
 
     val h1Component: Document               = Jsoup.parse(instanceOfH1(msgKey).body)
     val h1ComponentWithClass: Document      = Jsoup.parse(instanceOfH1(msgKey, classes = classes).body)

--- a/test/views/components/H1Spec.scala
+++ b/test/views/components/H1Spec.scala
@@ -75,7 +75,7 @@ class H1Spec extends SpecBase {
     val classes      = "custom-class"
     val id           = "custom-id"
 
-    val instanceOfH1: h1 = application.injector.instanceOf[h1]
+    val instanceOfH1: h1 = instanceOf[h1](application)
 
     val h1Component: Document               = Jsoup.parse(instanceOfH1(msgKey).body)
     val h1ComponentWithClass: Document      = Jsoup.parse(instanceOfH1(msgKey, classes = classes).body)

--- a/test/views/components/H1Spec.scala
+++ b/test/views/components/H1Spec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
+
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.h1
@@ -32,7 +32,7 @@ class H1Spec extends SpecBase {
     "display correct contents" when {
 
       "only message key has been provided" in new Setup {
-        h1Component.text() mustBe message(msgKey)
+        h1Component.text() mustBe messages(msgKey)
 
         val h1: Elements = h1Component.select("h1")
 
@@ -43,7 +43,7 @@ class H1Spec extends SpecBase {
       }
 
       "class has been provided along with message key" in new Setup {
-        h1ComponentWithClass.text() mustBe message(msgKey)
+        h1ComponentWithClass.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithClass.select("h1")
 
@@ -51,7 +51,7 @@ class H1Spec extends SpecBase {
       }
 
       "id has been provided along with message key" in new Setup {
-        h1ComponentWithId.text() mustBe message(msgKey)
+        h1ComponentWithId.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithId.select("h1")
 
@@ -59,7 +59,7 @@ class H1Spec extends SpecBase {
       }
 
       "classes and id have been provided along with message key" in new Setup {
-        h1ComponentWithClassAndId.text() mustBe message(msgKey)
+        h1ComponentWithClassAndId.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithClassAndId.select("h1")
 
@@ -75,9 +75,7 @@ class H1Spec extends SpecBase {
     val classes      = "custom-class"
     val id           = "custom-id"
 
-    val app: Application           = application().build()
-    implicit val message: Messages = messages(app)
-    val instanceOfH1: h1           = app.injector.instanceOf[h1]
+    val instanceOfH1: h1 = application.injector.instanceOf[h1]
 
     val h1Component: Document               = Jsoup.parse(instanceOfH1(msgKey).body)
     val h1ComponentWithClass: Document      = Jsoup.parse(instanceOfH1(msgKey, classes = classes).body)

--- a/test/views/components/H1Spec.scala
+++ b/test/views/components/H1Spec.scala
@@ -28,13 +28,11 @@ import views.html.components.h1
 
 class H1Spec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "h1 component" should {
 
     "display correct contents" when {
 
-      "only message key has been provided" in {
+      "only message key has been provided" in new Setup {
         h1Component.text() mustBe messages(msgKey)
 
         val h1: Elements = h1Component.select("h1")
@@ -45,7 +43,7 @@ class H1Spec extends SpecBase with GuiceOneAppPerSuite {
         h1.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with message key" in {
+      "class has been provided along with message key" in new Setup {
         h1ComponentWithClass.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithClass.select("h1")
@@ -53,7 +51,7 @@ class H1Spec extends SpecBase with GuiceOneAppPerSuite {
         h1.first().classNames() must contain(classes)
       }
 
-      "id has been provided along with message key" in {
+      "id has been provided along with message key" in new Setup {
         h1ComponentWithId.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithId.select("h1")
@@ -61,7 +59,7 @@ class H1Spec extends SpecBase with GuiceOneAppPerSuite {
         h1.first().attr("id") mustBe id
       }
 
-      "classes and id have been provided along with message key" in {
+      "classes and id have been provided along with message key" in new Setup {
         h1ComponentWithClassAndId.text() mustBe messages(msgKey)
 
         val h1: Elements = h1ComponentWithClassAndId.select("h1")
@@ -74,7 +72,7 @@ class H1Spec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val msgKey       = "messageKey"
     val defaultClass = "govuk-heading-l"
     val classes      = "custom-class"

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -74,7 +74,7 @@ class H2Spec extends SpecBase {
     val classes      = "custom-class"
     val id           = "custom-id"
 
-    val instanceOfH2: h2 = application.injector.instanceOf[h2]
+    val instanceOfH2: h2 = instanceOf[h2](application)
 
     val h2Component: Document               = Jsoup.parse(instanceOfH2(msgKey).body)
     val h2ComponentWithClass: Document      = Jsoup.parse(instanceOfH2(msgKey, classes = classes).body)

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -27,13 +27,11 @@ import views.html.components.h2
 
 class H2Spec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "h2 component" should {
 
     "display correct contents" when {
 
-      "only message key has been provided" in {
+      "only message key has been provided" in new Setup {
         h2Component.text() mustBe messages(msgKey)
 
         val h2: Elements = h2Component.select("h2")
@@ -44,7 +42,7 @@ class H2Spec extends SpecBase with GuiceOneAppPerSuite {
         h2.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with message key" in {
+      "class has been provided along with message key" in new Setup {
         h2ComponentWithClass.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithClass.select("h2")
@@ -52,7 +50,7 @@ class H2Spec extends SpecBase with GuiceOneAppPerSuite {
         h2.first().classNames() must contain(classes)
       }
 
-      "id has been provided along with message key" in {
+      "id has been provided along with message key" in new Setup {
         h2ComponentWithId.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithId.select("h2")
@@ -60,7 +58,7 @@ class H2Spec extends SpecBase with GuiceOneAppPerSuite {
         h2.first().attr("id") mustBe id
       }
 
-      "classes and id have been provided along with message key" in {
+      "classes and id have been provided along with message key" in new Setup {
         h2ComponentWithClassAndId.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithClassAndId.select("h2")
@@ -73,7 +71,7 @@ class H2Spec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val msgKey       = "messageKey"
     val defaultClass = "govuk-heading-m"
     val classes      = "custom-class"

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -20,7 +20,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.h2
@@ -32,7 +31,7 @@ class H2Spec extends SpecBase {
     "display correct contents" when {
 
       "only message key has been provided" in new Setup {
-        h2Component.text() mustBe message(msgKey)
+        h2Component.text() mustBe messages(msgKey)
 
         val h2: Elements = h2Component.select("h2")
 
@@ -43,7 +42,7 @@ class H2Spec extends SpecBase {
       }
 
       "class has been provided along with message key" in new Setup {
-        h2ComponentWithClass.text() mustBe message(msgKey)
+        h2ComponentWithClass.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithClass.select("h2")
 
@@ -51,7 +50,7 @@ class H2Spec extends SpecBase {
       }
 
       "id has been provided along with message key" in new Setup {
-        h2ComponentWithId.text() mustBe message(msgKey)
+        h2ComponentWithId.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithId.select("h2")
 
@@ -59,7 +58,7 @@ class H2Spec extends SpecBase {
       }
 
       "classes and id have been provided along with message key" in new Setup {
-        h2ComponentWithClassAndId.text() mustBe message(msgKey)
+        h2ComponentWithClassAndId.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithClassAndId.select("h2")
 
@@ -75,9 +74,7 @@ class H2Spec extends SpecBase {
     val classes      = "custom-class"
     val id           = "custom-id"
 
-    val app: Application           = application().build()
-    implicit val message: Messages = messages(app)
-    val instanceOfH2: h2           = app.injector.instanceOf[h2]
+    val instanceOfH2: h2 = application.injector.instanceOf[h2]
 
     val h2Component: Document               = Jsoup.parse(instanceOfH2(msgKey).body)
     val h2ComponentWithClass: Document      = Jsoup.parse(instanceOfH2(msgKey, classes = classes).body)

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -20,17 +20,20 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import utils.SpecBase
 import views.html.components.h2
 
-class H2Spec extends SpecBase {
+class H2Spec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "h2 component" should {
 
     "display correct contents" when {
 
-      "only message key has been provided" in new Setup {
+      "only message key has been provided" in {
         h2Component.text() mustBe messages(msgKey)
 
         val h2: Elements = h2Component.select("h2")
@@ -41,7 +44,7 @@ class H2Spec extends SpecBase {
         h2.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with message key" in new Setup {
+      "class has been provided along with message key" in {
         h2ComponentWithClass.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithClass.select("h2")
@@ -49,7 +52,7 @@ class H2Spec extends SpecBase {
         h2.first().classNames() must contain(classes)
       }
 
-      "id has been provided along with message key" in new Setup {
+      "id has been provided along with message key" in {
         h2ComponentWithId.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithId.select("h2")
@@ -57,7 +60,7 @@ class H2Spec extends SpecBase {
         h2.first().attr("id") mustBe id
       }
 
-      "classes and id have been provided along with message key" in new Setup {
+      "classes and id have been provided along with message key" in {
         h2ComponentWithClassAndId.text() mustBe messages(msgKey)
 
         val h2: Elements = h2ComponentWithClassAndId.select("h2")
@@ -68,13 +71,15 @@ class H2Spec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val msgKey       = "messageKey"
     val defaultClass = "govuk-heading-m"
     val classes      = "custom-class"
     val id           = "custom-id"
 
-    val instanceOfH2: h2 = instanceOf[h2](application)
+    val instanceOfH2: h2 = instanceOf[h2](app)
 
     val h2Component: Document               = Jsoup.parse(instanceOfH2(msgKey).body)
     val h2ComponentWithClass: Document      = Jsoup.parse(instanceOfH2(msgKey, classes = classes).body)

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -20,17 +20,20 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import utils.SpecBase
 import views.html.components.link
 
-class LinkSpec extends SpecBase {
+class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "link component" should {
 
     "display correct contents" when {
 
-      "only link message and location have been provided" in new Setup {
+      "only link message and location have been provided" in {
         linkComponent.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponent.select("a")
@@ -42,7 +45,7 @@ class LinkSpec extends SpecBase {
         link.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with link message and location" in new Setup {
+      "class has been provided along with link message and location" in {
         linkComponentWithClass.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithClass.select("a")
@@ -50,7 +53,7 @@ class LinkSpec extends SpecBase {
         link.first().classNames() must contain(classes)
       }
 
-      "id has been provided along with link message and location" in new Setup {
+      "id has been provided along with link message and location" in {
         linkComponentWithId.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithId.select("a")
@@ -58,7 +61,7 @@ class LinkSpec extends SpecBase {
         link.first().attr("id") mustBe linkId
       }
 
-      "classes and id have been provided along with link message and location" in new Setup {
+      "classes and id have been provided along with link message and location" in {
         linkComponentWithClassAndId.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithClassAndId.select("a")
@@ -67,7 +70,7 @@ class LinkSpec extends SpecBase {
         link.first().attr("id") mustBe linkId
       }
 
-      "aria-label has been provided along with link message and location" in new Setup {
+      "aria-label has been provided along with link message and location" in {
         linkComponentWithAriaLabel.text() must include(messages(linkMessage))
         linkComponentWithAriaLabel.text() must include(ariaLabelText)
 
@@ -78,7 +81,9 @@ class LinkSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val linkMessage   = "linkMessage"
     val location      = "jackie-chan.com"
     val defaultClass  = "govuk-link"
@@ -86,7 +91,7 @@ class LinkSpec extends SpecBase {
     val linkId        = "custom-id"
     val ariaLabelText = "visually hidden label"
 
-    val instanceOfLink: link = instanceOf[link](application)
+    val instanceOfLink: link = instanceOf[link](app)
 
     val linkComponent: Document          = Jsoup.parse(instanceOfLink(linkMessage, location).body)
     val linkComponentWithClass: Document = Jsoup.parse(instanceOfLink(linkMessage, location, linkClass = classes).body)

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -86,7 +86,7 @@ class LinkSpec extends SpecBase {
     val linkId        = "custom-id"
     val ariaLabelText = "visually hidden label"
 
-    val instanceOfLink: link = application.injector.instanceOf[link]
+    val instanceOfLink: link = instanceOf[link](application)
 
     val linkComponent: Document          = Jsoup.parse(instanceOfLink(linkMessage, location).body)
     val linkComponentWithClass: Document = Jsoup.parse(instanceOfLink(linkMessage, location, linkClass = classes).body)

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -27,13 +27,11 @@ import views.html.components.link
 
 class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "link component" should {
 
     "display correct contents" when {
 
-      "only link message and location have been provided" in {
+      "only link message and location have been provided" in new Setup {
         linkComponent.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponent.select("a")
@@ -45,7 +43,7 @@ class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
         link.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with link message and location" in {
+      "class has been provided along with link message and location" in new Setup {
         linkComponentWithClass.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithClass.select("a")
@@ -53,7 +51,7 @@ class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
         link.first().classNames() must contain(classes)
       }
 
-      "id has been provided along with link message and location" in {
+      "id has been provided along with link message and location" in new Setup {
         linkComponentWithId.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithId.select("a")
@@ -61,7 +59,7 @@ class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
         link.first().attr("id") mustBe linkId
       }
 
-      "classes and id have been provided along with link message and location" in {
+      "classes and id have been provided along with link message and location" in new Setup {
         linkComponentWithClassAndId.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithClassAndId.select("a")
@@ -70,7 +68,7 @@ class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
         link.first().attr("id") mustBe linkId
       }
 
-      "aria-label has been provided along with link message and location" in {
+      "aria-label has been provided along with link message and location" in new Setup {
         linkComponentWithAriaLabel.text() must include(messages(linkMessage))
         linkComponentWithAriaLabel.text() must include(ariaLabelText)
 
@@ -83,7 +81,7 @@ class LinkSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val linkMessage   = "linkMessage"
     val location      = "jackie-chan.com"
     val defaultClass  = "govuk-link"

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -20,7 +20,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.link
@@ -32,7 +31,7 @@ class LinkSpec extends SpecBase {
     "display correct contents" when {
 
       "only link message and location have been provided" in new Setup {
-        linkComponent.text() mustBe message(linkMessage)
+        linkComponent.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponent.select("a")
 
@@ -44,7 +43,7 @@ class LinkSpec extends SpecBase {
       }
 
       "class has been provided along with link message and location" in new Setup {
-        linkComponentWithClass.text() mustBe message(linkMessage)
+        linkComponentWithClass.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithClass.select("a")
 
@@ -52,7 +51,7 @@ class LinkSpec extends SpecBase {
       }
 
       "id has been provided along with link message and location" in new Setup {
-        linkComponentWithId.text() mustBe message(linkMessage)
+        linkComponentWithId.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithId.select("a")
 
@@ -60,7 +59,7 @@ class LinkSpec extends SpecBase {
       }
 
       "classes and id have been provided along with link message and location" in new Setup {
-        linkComponentWithClassAndId.text() mustBe message(linkMessage)
+        linkComponentWithClassAndId.text() mustBe messages(linkMessage)
 
         val link: Elements = linkComponentWithClassAndId.select("a")
 
@@ -69,7 +68,7 @@ class LinkSpec extends SpecBase {
       }
 
       "aria-label has been provided along with link message and location" in new Setup {
-        linkComponentWithAriaLabel.text() must include(message(linkMessage))
+        linkComponentWithAriaLabel.text() must include(messages(linkMessage))
         linkComponentWithAriaLabel.text() must include(ariaLabelText)
 
         val link: Elements = linkComponentWithAriaLabel.select("a")
@@ -87,9 +86,7 @@ class LinkSpec extends SpecBase {
     val linkId        = "custom-id"
     val ariaLabelText = "visually hidden label"
 
-    val app: Application           = application().build()
-    implicit val message: Messages = messages(app)
-    val instanceOfLink: link       = app.injector.instanceOf[link]
+    val instanceOfLink: link = application.injector.instanceOf[link]
 
     val linkComponent: Document          = Jsoup.parse(instanceOfLink(linkMessage, location).body)
     val linkComponentWithClass: Document = Jsoup.parse(instanceOfLink(linkMessage, location, linkClass = classes).body)
@@ -97,7 +94,8 @@ class LinkSpec extends SpecBase {
 
     val linkComponentWithClassAndId: Document =
       Jsoup.parse(instanceOfLink(linkMessage, location, linkId = Some(linkId), linkClass = classes).body)
-    val linkComponentWithAriaLabel: Document  =
+
+    val linkComponentWithAriaLabel: Document =
       Jsoup.parse(instanceOfLink(linkMessage, location, ariaLabel = Some(ariaLabelText)).body)
   }
 }

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -19,7 +19,7 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
+
 import play.api.test.Helpers._
 import play.twirl.api.{Html, HtmlFormat}
 import utils.SpecBase
@@ -29,57 +29,47 @@ class PSpec extends SpecBase {
 
   "P component" should {
 
-    "render the default class name when classes is not defined" in new SetUp {
-      running(app) {
-        val pView                         = app.injector.instanceOf[p]
-        val output: HtmlFormat.Appendable = pView(
-          message = "Hello, world!"
-        )(messages(app))
+    "render the default class name when classes is not defined" in {
+      val pView                         = application.injector.instanceOf[p]
+      val output: HtmlFormat.Appendable = pView(
+        message = "Hello, world!"
+      )(messages)
 
-        val html: Document = Jsoup.parse(contentAsString(output))
+      val html: Document = Jsoup.parse(contentAsString(output))
 
-        html.getElementsByTag("p").attr("class") must include("govuk-body")
-      }
+      html.getElementsByTag("p").attr("class") must include("govuk-body")
     }
 
-    "render the message and classes correctly without id, link, and tabLink" in new SetUp {
-      running(app) {
-        val pView                         = app.injector.instanceOf[p]
-        val output: HtmlFormat.Appendable = pView(
-          message = "Hello, world!",
-          classes = "custom-class"
-        )(messages(app))
+    "render the message and classes correctly without id, link, and tabLink" in {
+      val pView                         = application.injector.instanceOf[p]
+      val output: HtmlFormat.Appendable = pView(
+        message = "Hello, world!",
+        classes = "custom-class"
+      )(messages)
 
-        val html: Document = Jsoup.parse(contentAsString(output))
+      val html: Document = Jsoup.parse(contentAsString(output))
 
-        html.getElementsByClass("custom-class").text() must include("Hello, world!")
-      }
+      html.getElementsByClass("custom-class").text() must include("Hello, world!")
     }
 
-    "render the message, classes, and id correctly with link and tabLink" in new SetUp {
-      running(app) {
-        val linkContent = Html("<a href='/link'>Link</a>")
-        val tabContent  = Html("<a href='/tabLink'>Tab Link</a>")
-        val pView       = app.injector.instanceOf[p]
+    "render the message, classes, and id correctly with link and tabLink" in {
+      val linkContent = Html("<a href='/link'>Link</a>")
+      val tabContent  = Html("<a href='/tabLink'>Tab Link</a>")
+      val pView       = application.injector.instanceOf[p]
 
-        val output: HtmlFormat.Appendable = pView(
-          message = "Hello, world!",
-          classes = "custom-class",
-          id = Some("test-id"),
-          link = Some(linkContent),
-          tabLink = Some(tabContent)
-        )(messages(app))
+      val output: HtmlFormat.Appendable = pView(
+        message = "Hello, world!",
+        classes = "custom-class",
+        id = Some("test-id"),
+        link = Some(linkContent),
+        tabLink = Some(tabContent)
+      )(messages)
 
-        val html: Document = Jsoup.parse(contentAsString(output))
+      val html: Document = Jsoup.parse(contentAsString(output))
 
-        html.getElementById("test-id").text() must include("Hello, world!")
-        html.getElementById("test-id").select("a").get(0).text() mustBe "Link"
-        html.getElementById("test-id").select("a").get(1).text() mustBe "Tab Link"
-      }
+      html.getElementById("test-id").text() must include("Hello, world!")
+      html.getElementById("test-id").select("a").get(0).text() mustBe "Link"
+      html.getElementById("test-id").select("a").get(1).text() mustBe "Tab Link"
     }
-  }
-
-  trait SetUp {
-    val app: Application = application().build()
   }
 }

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -30,7 +30,7 @@ class PSpec extends SpecBase {
   "P component" should {
 
     "render the default class name when classes is not defined" in {
-      val pView                         = application.injector.instanceOf[p]
+      val pView                         = instanceOf[p](application)
       val output: HtmlFormat.Appendable = pView(
         message = "Hello, world!"
       )(messages)
@@ -41,7 +41,7 @@ class PSpec extends SpecBase {
     }
 
     "render the message and classes correctly without id, link, and tabLink" in {
-      val pView                         = application.injector.instanceOf[p]
+      val pView                         = instanceOf[p](application)
       val output: HtmlFormat.Appendable = pView(
         message = "Hello, world!",
         classes = "custom-class"
@@ -55,7 +55,7 @@ class PSpec extends SpecBase {
     "render the message, classes, and id correctly with link and tabLink" in {
       val linkContent = Html("<a href='/link'>Link</a>")
       val tabContent  = Html("<a href='/tabLink'>Tab Link</a>")
-      val pView       = application.injector.instanceOf[p]
+      val pView       = instanceOf[p](application)
 
       val output: HtmlFormat.Appendable = pView(
         message = "Hello, world!",

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -19,18 +19,19 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-
-import play.api.test.Helpers._
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.test.Helpers.*
 import play.twirl.api.{Html, HtmlFormat}
 import utils.SpecBase
 import views.html.components.p
 
-class PSpec extends SpecBase {
+class PSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "P component" should {
 
     "render the default class name when classes is not defined" in {
-      val pView                         = instanceOf[p](application)
+      val pView                         = instanceOf[p](app)
       val output: HtmlFormat.Appendable = pView(
         message = "Hello, world!"
       )(messages)
@@ -41,7 +42,7 @@ class PSpec extends SpecBase {
     }
 
     "render the message and classes correctly without id, link, and tabLink" in {
-      val pView                         = instanceOf[p](application)
+      val pView                         = instanceOf[p](app)
       val output: HtmlFormat.Appendable = pView(
         message = "Hello, world!",
         classes = "custom-class"
@@ -55,7 +56,7 @@ class PSpec extends SpecBase {
     "render the message, classes, and id correctly with link and tabLink" in {
       val linkContent = Html("<a href='/link'>Link</a>")
       val tabContent  = Html("<a href='/tabLink'>Tab Link</a>")
-      val pView       = instanceOf[p](application)
+      val pView       = instanceOf[p](app)
 
       val output: HtmlFormat.Appendable = pView(
         message = "Hello, world!",
@@ -72,4 +73,6 @@ class PSpec extends SpecBase {
       html.getElementById("test-id").select("a").get(1).text() mustBe "Tab Link"
     }
   }
+
+  override def fakeApplication(): Application = applicationBuilder.build()
 }

--- a/test/views/components/RequestedStatementsSpec.scala
+++ b/test/views/components/RequestedStatementsSpec.scala
@@ -20,19 +20,22 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import utils.CommonTestData.URL_TEST
 import utils.SpecBase
 import views.html.components.requestedStatements
 
-class RequestedStatementsSpec extends SpecBase {
+class RequestedStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "view" should {
 
     "display correct contents" when {
 
-      "only url is provided" in new Setup {
+      "only url is provided" in {
 
         val viewDoc: Document = view(URL_TEST)
 
@@ -45,7 +48,7 @@ class RequestedStatementsSpec extends SpecBase {
         )
       }
 
-      "all the arguments' value are provided" in new Setup {
+      "all the arguments' value are provided" in {
         val viewDoc: Document = view(URL_TEST)
 
         shouldContainTheParagraphWithCorrectStyleClass(viewDoc)
@@ -76,9 +79,11 @@ class RequestedStatementsSpec extends SpecBase {
     docHtml.contains(messages(postLinkMessage)) mustBe true
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
 
-    protected def view(url: String): Document =
-      Jsoup.parse(instanceOf[requestedStatements](application).apply(url).body)
+  object Setup {
+
+    def view(url: String): Document =
+      Jsoup.parse(instanceOf[requestedStatements](app).apply(url).body)
   }
 }

--- a/test/views/components/RequestedStatementsSpec.scala
+++ b/test/views/components/RequestedStatementsSpec.scala
@@ -79,6 +79,6 @@ class RequestedStatementsSpec extends SpecBase {
   trait Setup {
 
     protected def view(url: String): Document =
-      Jsoup.parse(application.injector.instanceOf[requestedStatements].apply(url).body)
+      Jsoup.parse(instanceOf[requestedStatements](application).apply(url).body)
   }
 }

--- a/test/views/components/RequestedStatementsSpec.scala
+++ b/test/views/components/RequestedStatementsSpec.scala
@@ -29,13 +29,11 @@ import views.html.components.requestedStatements
 
 class RequestedStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "view" should {
 
     "display correct contents" when {
 
-      "only url is provided" in {
+      "only url is provided" in new Setup {
 
         val viewDoc: Document = view(URL_TEST)
 
@@ -48,7 +46,7 @@ class RequestedStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
         )
       }
 
-      "all the arguments' value are provided" in {
+      "all the arguments' value are provided" in new Setup {
         val viewDoc: Document = view(URL_TEST)
 
         shouldContainTheParagraphWithCorrectStyleClass(viewDoc)
@@ -81,7 +79,7 @@ class RequestedStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
 
     def view(url: String): Document =
       Jsoup.parse(instanceOf[requestedStatements](app).apply(url).body)

--- a/test/views/components/RequestedStatementsSpec.scala
+++ b/test/views/components/RequestedStatementsSpec.scala
@@ -20,7 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import utils.CommonTestData.URL_TEST
 import utils.SpecBase
@@ -71,16 +71,14 @@ class RequestedStatementsSpec extends SpecBase {
     val docHtml = doc.html()
 
     docHtml.contains(URL_TEST) mustBe true
-    docHtml.contains(msgs(linkMessageKey)) mustBe true
-    docHtml.contains(msgs(preLinkMessage)) mustBe true
-    docHtml.contains(msgs(postLinkMessage)) mustBe true
+    docHtml.contains(messages(linkMessageKey)) mustBe true
+    docHtml.contains(messages(preLinkMessage)) mustBe true
+    docHtml.contains(messages(postLinkMessage)) mustBe true
   }
 
   trait Setup {
-    val app: Application        = application().build()
-    implicit val msgs: Messages = messages(app)
 
     protected def view(url: String): Document =
-      Jsoup.parse(app.injector.instanceOf[requestedStatements].apply(url).body)
+      Jsoup.parse(application.injector.instanceOf[requestedStatements].apply(url).body)
   }
 }

--- a/test/views/components/SpanSpec.scala
+++ b/test/views/components/SpanSpec.scala
@@ -20,17 +20,20 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import utils.SpecBase
 import views.html.components.span
 
-class SpanSpec extends SpecBase {
+class SpanSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "span component" should {
 
     "display correct contents" when {
 
-      "only message key has been provided" in new Setup {
+      "only message key has been provided" in {
         spanComponent.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponent.select("span")
@@ -40,7 +43,7 @@ class SpanSpec extends SpecBase {
         span.first().hasAttr("aria-hidden") mustBe false
       }
 
-      "class has been provided along with message key" in new Setup {
+      "class has been provided along with message key" in {
         spanComponentWithClass.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithClass.select("span")
@@ -49,7 +52,7 @@ class SpanSpec extends SpecBase {
         span.first().classNames() must contain(classes)
       }
 
-      "ariaHidden has been provided along with message key" in new Setup {
+      "ariaHidden has been provided along with message key" in {
         spanComponentWithAriaHidden.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithAriaHidden.select("span")
@@ -58,7 +61,7 @@ class SpanSpec extends SpecBase {
         span.first().attr("aria-hidden") mustBe ariaHidden
       }
 
-      "classes and ariaHidden have been provided along with message key" in new Setup {
+      "classes and ariaHidden have been provided along with message key" in {
         spanComponentWithClassAndAriaHidden.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithClassAndAriaHidden.select("span")
@@ -70,12 +73,14 @@ class SpanSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val msgKey     = "messageKey"
     val classes    = "custom-class"
     val ariaHidden = "true"
 
-    val instanceOfSpan: span = instanceOf[span](application)
+    val instanceOfSpan: span = instanceOf[span](app)
 
     val spanComponent: Document               = Jsoup.parse(instanceOfSpan(msgKey).body)
     val spanComponentWithClass: Document      = Jsoup.parse(instanceOfSpan(msgKey, classes = Some(classes)).body)

--- a/test/views/components/SpanSpec.scala
+++ b/test/views/components/SpanSpec.scala
@@ -27,13 +27,11 @@ import views.html.components.span
 
 class SpanSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "span component" should {
 
     "display correct contents" when {
 
-      "only message key has been provided" in {
+      "only message key has been provided" in new Setup {
         spanComponent.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponent.select("span")
@@ -43,7 +41,7 @@ class SpanSpec extends SpecBase with GuiceOneAppPerSuite {
         span.first().hasAttr("aria-hidden") mustBe false
       }
 
-      "class has been provided along with message key" in {
+      "class has been provided along with message key" in new Setup {
         spanComponentWithClass.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithClass.select("span")
@@ -52,7 +50,7 @@ class SpanSpec extends SpecBase with GuiceOneAppPerSuite {
         span.first().classNames() must contain(classes)
       }
 
-      "ariaHidden has been provided along with message key" in {
+      "ariaHidden has been provided along with message key" in new Setup {
         spanComponentWithAriaHidden.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithAriaHidden.select("span")
@@ -61,7 +59,7 @@ class SpanSpec extends SpecBase with GuiceOneAppPerSuite {
         span.first().attr("aria-hidden") mustBe ariaHidden
       }
 
-      "classes and ariaHidden have been provided along with message key" in {
+      "classes and ariaHidden have been provided along with message key" in new Setup {
         spanComponentWithClassAndAriaHidden.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithClassAndAriaHidden.select("span")
@@ -75,7 +73,7 @@ class SpanSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val msgKey     = "messageKey"
     val classes    = "custom-class"
     val ariaHidden = "true"

--- a/test/views/components/SpanSpec.scala
+++ b/test/views/components/SpanSpec.scala
@@ -20,7 +20,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.span
@@ -32,7 +31,7 @@ class SpanSpec extends SpecBase {
     "display correct contents" when {
 
       "only message key has been provided" in new Setup {
-        spanComponent.text() mustBe message(msgKey)
+        spanComponent.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponent.select("span")
 
@@ -42,7 +41,7 @@ class SpanSpec extends SpecBase {
       }
 
       "class has been provided along with message key" in new Setup {
-        spanComponentWithClass.text() mustBe message(msgKey)
+        spanComponentWithClass.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithClass.select("span")
 
@@ -51,7 +50,7 @@ class SpanSpec extends SpecBase {
       }
 
       "ariaHidden has been provided along with message key" in new Setup {
-        spanComponentWithAriaHidden.text() mustBe message(msgKey)
+        spanComponentWithAriaHidden.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithAriaHidden.select("span")
 
@@ -60,7 +59,7 @@ class SpanSpec extends SpecBase {
       }
 
       "classes and ariaHidden have been provided along with message key" in new Setup {
-        spanComponentWithClassAndAriaHidden.text() mustBe message(msgKey)
+        spanComponentWithClassAndAriaHidden.text() mustBe messages(msgKey)
 
         val span: Elements = spanComponentWithClassAndAriaHidden.select("span")
 
@@ -76,9 +75,7 @@ class SpanSpec extends SpecBase {
     val classes    = "custom-class"
     val ariaHidden = "true"
 
-    val app: Application           = application().build()
-    implicit val message: Messages = messages(app)
-    val instanceOfSpan: span       = app.injector.instanceOf[span]
+    val instanceOfSpan: span = application.injector.instanceOf[span]
 
     val spanComponent: Document               = Jsoup.parse(instanceOfSpan(msgKey).body)
     val spanComponentWithClass: Document      = Jsoup.parse(instanceOfSpan(msgKey, classes = Some(classes)).body)

--- a/test/views/components/SpanSpec.scala
+++ b/test/views/components/SpanSpec.scala
@@ -75,7 +75,7 @@ class SpanSpec extends SpecBase {
     val classes    = "custom-class"
     val ariaHidden = "true"
 
-    val instanceOfSpan: span = application.injector.instanceOf[span]
+    val instanceOfSpan: span = instanceOf[span](application)
 
     val spanComponent: Document               = Jsoup.parse(instanceOfSpan(msgKey).body)
     val spanComponentWithClass: Document      = Jsoup.parse(instanceOfSpan(msgKey, classes = Some(classes)).body)

--- a/test/views/components/description_list/DescriptionListSpec.scala
+++ b/test/views/components/description_list/DescriptionListSpec.scala
@@ -20,19 +20,22 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.i18n.Messages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.twirl.api.Html
 import utils.SpecBase
 import views.html.components.description_list.{dd, dl, dt}
 import utils.Utils.singleSpace
 
-class DescriptionListSpec extends SpecBase {
+class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "dd component" should {
 
     "display correct contents" when {
 
-      "only content has been provided" in new Setup {
+      "only content has been provided" in {
         val dd: Elements = ddComponent.select("dd")
 
         dd.text() mustBe contentText
@@ -40,7 +43,7 @@ class DescriptionListSpec extends SpecBase {
         dd.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in new Setup {
+      "class has been provided along with content" in {
         val dd: Elements = ddComponentWithClass.select("dd")
 
         dd.text() mustBe contentText
@@ -48,7 +51,7 @@ class DescriptionListSpec extends SpecBase {
         dd.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in new Setup {
+      "id has been provided along with content" in {
         val dd: Elements = ddComponentWithId.select("dd")
 
         dd.text() mustBe contentText
@@ -56,7 +59,7 @@ class DescriptionListSpec extends SpecBase {
         dd.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in new Setup {
+      "both class and id have been provided along with content" in {
         val dd: Elements = ddComponentWithClassAndId.select("dd")
 
         dd.text() mustBe contentText
@@ -70,7 +73,7 @@ class DescriptionListSpec extends SpecBase {
 
     "display correct contents" when {
 
-      "only content has been provided" in new Setup {
+      "only content has been provided" in {
         val dl: Elements = dlComponent.select("dl")
 
         dl.html() mustBe contentText
@@ -78,7 +81,7 @@ class DescriptionListSpec extends SpecBase {
         dl.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in new Setup {
+      "class has been provided along with content" in {
         val dl: Elements = dlComponentWithClass.select("dl")
 
         dl.html() mustBe contentText
@@ -88,7 +91,7 @@ class DescriptionListSpec extends SpecBase {
         dl.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in new Setup {
+      "id has been provided along with content" in {
         val dl: Elements = dlComponentWithId.select("dl")
 
         dl.html() mustBe contentText
@@ -96,7 +99,7 @@ class DescriptionListSpec extends SpecBase {
         dl.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in new Setup {
+      "both class and id have been provided along with content" in {
         val dl: Elements = dlComponentWithClassAndId.select("dl")
 
         dl.html() mustBe contentText
@@ -110,7 +113,7 @@ class DescriptionListSpec extends SpecBase {
 
     "display correct contents" when {
 
-      "only content has been provided" in new Setup {
+      "only content has been provided" in {
         val dt: Elements = dtComponent.select("dt")
 
         dt.text() mustBe contentText
@@ -118,7 +121,7 @@ class DescriptionListSpec extends SpecBase {
         dt.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in new Setup {
+      "class has been provided along with content" in {
         val dt: Elements = dtComponentWithClass.select("dt")
 
         dt.text() mustBe contentText
@@ -126,7 +129,7 @@ class DescriptionListSpec extends SpecBase {
         dt.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in new Setup {
+      "id has been provided along with content" in {
         val dt: Elements = dtComponentWithId.select("dt")
 
         dt.text() mustBe contentText
@@ -134,7 +137,7 @@ class DescriptionListSpec extends SpecBase {
         dt.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in new Setup {
+      "both class and id have been provided along with content" in {
         val dt: Elements = dtComponentWithClassAndId.select("dt")
 
         dt.text() mustBe contentText
@@ -144,7 +147,9 @@ class DescriptionListSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val contentText          = "some content"
     val content: Html        = Html(contentText)
     val testClass            = "test-class"
@@ -153,9 +158,9 @@ class DescriptionListSpec extends SpecBase {
     val testMultipleClassses = s"$testClass$singleSpace$testClass1$singleSpace$testClass2"
     val testId               = "test-id"
 
-    val instanceOfDd: dd = instanceOf[dd](application)
-    val instanceOfDl: dl = instanceOf[dl](application)
-    val instanceOfDt: dt = instanceOf[dt](application)
+    val instanceOfDd: dd = instanceOf[dd](app)
+    val instanceOfDl: dl = instanceOf[dl](app)
+    val instanceOfDt: dt = instanceOf[dt](app)
 
     val ddComponent: Document               = Jsoup.parse(instanceOfDd(content).body)
     val ddComponentWithClass: Document      = Jsoup.parse(instanceOfDd(content, classes = Some(testClass)).body)

--- a/test/views/components/description_list/DescriptionListSpec.scala
+++ b/test/views/components/description_list/DescriptionListSpec.scala
@@ -153,9 +153,9 @@ class DescriptionListSpec extends SpecBase {
     val testMultipleClassses = s"$testClass$singleSpace$testClass1$singleSpace$testClass2"
     val testId               = "test-id"
 
-    val instanceOfDd: dd = application.injector.instanceOf[dd]
-    val instanceOfDl: dl = application.injector.instanceOf[dl]
-    val instanceOfDt: dt = application.injector.instanceOf[dt]
+    val instanceOfDd: dd = instanceOf[dd](application)
+    val instanceOfDl: dl = instanceOf[dl](application)
+    val instanceOfDt: dt = instanceOf[dt](application)
 
     val ddComponent: Document               = Jsoup.parse(instanceOfDd(content).body)
     val ddComponentWithClass: Document      = Jsoup.parse(instanceOfDd(content, classes = Some(testClass)).body)

--- a/test/views/components/description_list/DescriptionListSpec.scala
+++ b/test/views/components/description_list/DescriptionListSpec.scala
@@ -20,7 +20,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.{must, mustBe}
-import play.api.Application
 import play.api.i18n.Messages
 import play.twirl.api.Html
 import utils.SpecBase
@@ -154,12 +153,9 @@ class DescriptionListSpec extends SpecBase {
     val testMultipleClassses = s"$testClass$singleSpace$testClass1$singleSpace$testClass2"
     val testId               = "test-id"
 
-    val app: Application           = application().build()
-    implicit val message: Messages = messages(app)
-
-    val instanceOfDd: dd = app.injector.instanceOf[dd]
-    val instanceOfDl: dl = app.injector.instanceOf[dl]
-    val instanceOfDt: dt = app.injector.instanceOf[dt]
+    val instanceOfDd: dd = application.injector.instanceOf[dd]
+    val instanceOfDl: dl = application.injector.instanceOf[dl]
+    val instanceOfDt: dt = application.injector.instanceOf[dt]
 
     val ddComponent: Document               = Jsoup.parse(instanceOfDd(content).body)
     val ddComponentWithClass: Document      = Jsoup.parse(instanceOfDd(content, classes = Some(testClass)).body)

--- a/test/views/components/description_list/DescriptionListSpec.scala
+++ b/test/views/components/description_list/DescriptionListSpec.scala
@@ -29,13 +29,11 @@ import utils.Utils.singleSpace
 
 class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "dd component" should {
 
     "display correct contents" when {
 
-      "only content has been provided" in {
+      "only content has been provided" in new Setup {
         val dd: Elements = ddComponent.select("dd")
 
         dd.text() mustBe contentText
@@ -43,7 +41,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dd.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in {
+      "class has been provided along with content" in new Setup {
         val dd: Elements = ddComponentWithClass.select("dd")
 
         dd.text() mustBe contentText
@@ -51,7 +49,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dd.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in {
+      "id has been provided along with content" in new Setup {
         val dd: Elements = ddComponentWithId.select("dd")
 
         dd.text() mustBe contentText
@@ -59,7 +57,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dd.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in {
+      "both class and id have been provided along with content" in new Setup {
         val dd: Elements = ddComponentWithClassAndId.select("dd")
 
         dd.text() mustBe contentText
@@ -73,7 +71,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
 
     "display correct contents" when {
 
-      "only content has been provided" in {
+      "only content has been provided" in new Setup {
         val dl: Elements = dlComponent.select("dl")
 
         dl.html() mustBe contentText
@@ -81,7 +79,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dl.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in {
+      "class has been provided along with content" in new Setup {
         val dl: Elements = dlComponentWithClass.select("dl")
 
         dl.html() mustBe contentText
@@ -91,7 +89,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dl.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in {
+      "id has been provided along with content" in new Setup {
         val dl: Elements = dlComponentWithId.select("dl")
 
         dl.html() mustBe contentText
@@ -99,7 +97,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dl.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in {
+      "both class and id have been provided along with content" in new Setup {
         val dl: Elements = dlComponentWithClassAndId.select("dl")
 
         dl.html() mustBe contentText
@@ -113,7 +111,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
 
     "display correct contents" when {
 
-      "only content has been provided" in {
+      "only content has been provided" in new Setup {
         val dt: Elements = dtComponent.select("dt")
 
         dt.text() mustBe contentText
@@ -121,7 +119,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dt.first().hasAttr("id") mustBe false
       }
 
-      "class has been provided along with content" in {
+      "class has been provided along with content" in new Setup {
         val dt: Elements = dtComponentWithClass.select("dt")
 
         dt.text() mustBe contentText
@@ -129,7 +127,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dt.first().hasAttr("id") mustBe false
       }
 
-      "id has been provided along with content" in {
+      "id has been provided along with content" in new Setup {
         val dt: Elements = dtComponentWithId.select("dt")
 
         dt.text() mustBe contentText
@@ -137,7 +135,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
         dt.first().attr("id") mustBe testId
       }
 
-      "both class and id have been provided along with content" in {
+      "both class and id have been provided along with content" in new Setup {
         val dt: Elements = dtComponentWithClassAndId.select("dt")
 
         dt.text() mustBe contentText
@@ -149,7 +147,7 @@ class DescriptionListSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val contentText          = "some content"
     val content: Html        = Html(contentText)
     val testClass            = "test-class"

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -16,22 +16,23 @@
 
 package views.email
 
-import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.mustBe
-
-import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
 import views.html.email.undeliverable_email
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 
-class UndeliverableEmailSpec extends SpecBase {
+class UndeliverableEmailSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "view" should {
 
-    "display correct guidance and text" in new Setup {
+    "display correct guidance and text" in {
 
       view.title() mustBe
         s"${messages("cf.undeliverable.email.title")} - ${messages("service.name")} - GOV.UK"
@@ -54,21 +55,23 @@ class UndeliverableEmailSpec extends SpecBase {
       view.text().contains(email.get) mustBe true
     }
 
-    "not display the email paragraph if there is no email" in new Setup {
+    "not display the email paragraph if there is no email" in {
       viewWithNoEmail.text().contains(email.get) mustBe false
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val nextPageUrl           = "test_url"
     val email: Option[String] = Some("test@test.com")
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(instanceOf[undeliverable_email](application).apply(nextPageUrl, email).body)
+      Jsoup.parse(instanceOf[undeliverable_email](app).apply(nextPageUrl, email).body)
 
     val viewWithNoEmail: Document =
-      Jsoup.parse(instanceOf[undeliverable_email](application).apply(nextPageUrl).body)
+      Jsoup.parse(instanceOf[undeliverable_email](app).apply(nextPageUrl).body)
   }
 }

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -34,21 +34,21 @@ class UndeliverableEmailSpec extends SpecBase {
     "display correct guidance and text" in new Setup {
 
       view.title() mustBe
-        s"${messages(app)("cf.undeliverable.email.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.undeliverable.email.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementsByTag("h1").text() mustBe messages(app)("cf.undeliverable.email.heading")
+      view.getElementsByTag("h1").text() mustBe messages("cf.undeliverable.email.heading")
 
-      view.text().contains(messages(app)("cf.undeliverable.email.p1")) mustBe true
-      view.html.contains(messages(app)("cf.undeliverable.email.p2", email))
+      view.text().contains(messages("cf.undeliverable.email.p1")) mustBe true
+      view.html.contains(messages("cf.undeliverable.email.p2", email))
 
-      view.text().contains(messages(app)("cf.undeliverable.email.verify.heading")) mustBe true
-      view.text().contains(messages(app)("cf.undeliverable.email.verify.text.p1")) mustBe true
-      view.text().contains(messages(app)("cf.undeliverable.email.change.heading")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.verify.heading")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.verify.text.p1")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.change.heading")) mustBe true
 
-      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p1")) mustBe true
-      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p2")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.change.text.p1")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.change.text.p2")) mustBe true
 
-      view.text().contains(messages(app)("cf.undeliverable.email.link-text")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.link-text")) mustBe true
 
       view.toString should include(nextPageUrl)
       view.text().contains(email.get) mustBe true
@@ -60,16 +60,15 @@ class UndeliverableEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application      = application().build()
     val nextPageUrl           = "test_url"
     val email: Option[String] = Some("test@test.com")
 
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
+    val view: Document =
+      Jsoup.parse(application.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
 
-    val viewWithNoEmail: Document = Jsoup.parse(app.injector.instanceOf[undeliverable_email].apply(nextPageUrl).body)
+    val viewWithNoEmail: Document =
+      Jsoup.parse(application.injector.instanceOf[undeliverable_email].apply(nextPageUrl).body)
   }
 }

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -28,11 +28,9 @@ import play.api.Application
 
 class UndeliverableEmailSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "view" should {
 
-    "display correct guidance and text" in {
+    "display correct guidance and text" in new Setup {
 
       view.title() mustBe
         s"${messages("cf.undeliverable.email.title")} - ${messages("service.name")} - GOV.UK"
@@ -55,14 +53,14 @@ class UndeliverableEmailSpec extends SpecBase with GuiceOneAppPerSuite {
       view.text().contains(email.get) mustBe true
     }
 
-    "not display the email paragraph if there is no email" in {
+    "not display the email paragraph if there is no email" in new Setup {
       viewWithNoEmail.text().contains(email.get) mustBe false
     }
   }
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val nextPageUrl           = "test_url"
     val email: Option[String] = Some("test@test.com")
 

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -66,9 +66,9 @@ class UndeliverableEmailSpec extends SpecBase {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(application.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
+      Jsoup.parse(instanceOf[undeliverable_email](application).apply(nextPageUrl, email).body)
 
     val viewWithNoEmail: Document =
-      Jsoup.parse(application.injector.instanceOf[undeliverable_email].apply(nextPageUrl).body)
+      Jsoup.parse(instanceOf[undeliverable_email](application).apply(nextPageUrl).body)
   }
 }

--- a/test/views/helpers/FormattersSpec.scala
+++ b/test/views/helpers/FormattersSpec.scala
@@ -22,44 +22,46 @@ import views.helpers.Formatters.fileSize
 
 class FormattersSpec extends SpecBase {
 
+  import Setup.*
+
   "Formatters" should {
-    "display 1KB when fileSize is passed a value below 1KB" in new Setup {
-      private val res = fileSize(belowKbThreshold)
+    "display 1KB when fileSize is passed a value below 1KB" in {
+      val res = fileSize(belowKbThreshold)
       res mustBe "1KB"
     }
 
-    "display a valid KB when fileSize is passed an amount above 1KB and below 1MB" in new Setup {
-      private val res = fileSize(kbValue)
+    "display a valid KB when fileSize is passed an amount above 1KB and below 1MB" in {
+      val res = fileSize(kbValue)
       res mustBe "29KB"
     }
 
-    "display a valid MB when fileSize is passed an amount above the KB limit" in new Setup {
-      private val res = fileSize(mbValue)
+    "display a valid MB when fileSize is passed an amount above the KB limit" in {
+      val res = fileSize(mbValue)
       res mustBe "19.6MB"
     }
 
-    "display 1KB when the fileSize is on the KB threshold" in new Setup {
-      private val res = fileSize(kbThreshold)
+    "display 1KB when the fileSize is on the KB threshold" in {
+      val res = fileSize(kbThreshold)
       res mustBe "1KB"
     }
 
-    "display 1.0MB when the fileSize is on the MB threshold" in new Setup {
-      private val res = fileSize(mbThreshold)
+    "display 1.0MB when the fileSize is on the MB threshold" in {
+      val res = fileSize(mbThreshold)
       res mustBe "1.0MB"
     }
 
-    "display 2KB when fileSize is over the KB threshold by 1" in new Setup {
-      private val res = fileSize(kbThreshold + 1024)
+    "display 2KB when fileSize is over the KB threshold by 1" in {
+      val res = fileSize(kbThreshold + 1024)
       res mustBe "2KB"
     }
 
-    "display 2.0MB when fileSize is over the MB threshold by 1" in new Setup {
-      private val res = fileSize(mbThreshold + 1024 * 1024)
+    "display 2.0MB when fileSize is over the MB threshold by 1" in {
+      val res = fileSize(mbThreshold + 1024 * 1024)
       res mustBe "2.0MB"
     }
   }
 
-  trait Setup {
+  object Setup {
     val belowKbThreshold = 100
     val kbValue          = 30567
     val mbValue          = 20567567

--- a/test/views/import_vat/ImportVatNotAvailableSpec.scala
+++ b/test/views/import_vat/ImportVatNotAvailableSpec.scala
@@ -58,6 +58,6 @@ class ImportVatNotAvailableSpec extends SpecBase {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(application.injector.instanceOf[import_vat_not_available].apply(Option(serviceUnavailableUrl)).body)
+      Jsoup.parse(instanceOf[import_vat_not_available](application).apply(Option(serviceUnavailableUrl)).body)
   }
 }

--- a/test/views/import_vat/ImportVatNotAvailableSpec.scala
+++ b/test/views/import_vat/ImportVatNotAvailableSpec.scala
@@ -20,18 +20,21 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.mustBe
-
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
 import views.html.import_vat.import_vat_not_available
 
-class ImportVatNotAvailableSpec extends SpecBase {
+class ImportVatNotAvailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "ImportVatNotAvailable view" should {
 
-    "display correct title and guidance" in new Setup {
+    "display correct title and guidance" in {
+      import Setup.*
+
       view.title() mustBe
         s"${messages("cf.account.vat.title")} - ${messages("service.name")} - GOV.UK"
 
@@ -52,12 +55,14 @@ class ImportVatNotAvailableSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val serviceUnavailableUrl: String = "service_unavailable_url"
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(instanceOf[import_vat_not_available](application).apply(Option(serviceUnavailableUrl)).body)
+      Jsoup.parse(instanceOf[import_vat_not_available](app).apply(Option(serviceUnavailableUrl)).body)
   }
 }

--- a/test/views/import_vat/ImportVatNotAvailableSpec.scala
+++ b/test/views/import_vat/ImportVatNotAvailableSpec.scala
@@ -32,8 +32,7 @@ class ImportVatNotAvailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "ImportVatNotAvailable view" should {
 
-    "display correct title and guidance" in {
-      import Setup.*
+    "display correct title and guidance" in new Setup {
 
       view.title() mustBe
         s"${messages("cf.account.vat.title")} - ${messages("service.name")} - GOV.UK"
@@ -57,7 +56,7 @@ class ImportVatNotAvailableSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val serviceUnavailableUrl: String = "service_unavailable_url"
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")

--- a/test/views/import_vat/ImportVatNotAvailableSpec.scala
+++ b/test/views/import_vat/ImportVatNotAvailableSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -33,34 +33,31 @@ class ImportVatNotAvailableSpec extends SpecBase {
 
     "display correct title and guidance" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.account.vat.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.account.vat.title")} - ${messages("service.name")} - GOV.UK"
 
       view.getElementById("missing-certificates-guidance-heading").html() mustBe
-        messages(app)("cf.account.vat.older-certificates.heading")
+        messages("cf.account.vat.older-certificates.heading")
 
       view.getElementById("chief-guidance-heading").html() mustBe
-        messages(app)("cf.account.vat.chief.heading")
+        messages("cf.account.vat.chief.heading")
 
       view.getElementById("vat.support.message.heading").html() mustBe
-        messages(app)("cf.account.vat.support.heading")
+        messages("cf.account.vat.support.heading")
 
-      view.html().contains(messages(app)("cf.account.vat.older-certificates.description.link"))
-      view.html().contains(messages(app)("cf.account.vat.older-certificates.description.1"))
-      view.html().contains(messages(app)("cf.account.vat.older-certificates.description.2"))
-      view.html().contains(messages(app)("cf.account.vat.support.link"))
+      view.html().contains(messages("cf.account.vat.older-certificates.description.link"))
+      view.html().contains(messages("cf.account.vat.older-certificates.description.1"))
+      view.html().contains(messages("cf.account.vat.older-certificates.description.2"))
+      view.html().contains(messages("cf.account.vat.support.link"))
       view.html().contains(serviceUnavailableUrl)
     }
   }
 
   trait Setup {
-    val app: Application              = application().build()
     val serviceUnavailableUrl: String = "service_unavailable_url"
 
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document =
-      Jsoup.parse(app.injector.instanceOf[import_vat_not_available].apply(Option(serviceUnavailableUrl)).body)
+      Jsoup.parse(application.injector.instanceOf[import_vat_not_available].apply(Option(serviceUnavailableUrl)).body)
   }
 }

--- a/test/views/import_vat/ImportVatSpec.scala
+++ b/test/views/import_vat/ImportVatSpec.scala
@@ -28,6 +28,8 @@ import viewmodels.ImportVatViewModel
 import views.html.import_vat.import_vat
 import models.{VatCertificatesByMonth, VatCertificatesForEori}
 import org.scalatest.matchers.must.Matchers.mustBe
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import utils.CommonTestData.{
   DAY_28, EORI_NUMBER, FIVE_MONTHS, FOUR_MONTHS, ONE_MONTH, SIX_MONTHS, THREE_MONTHS, TWO_MONTHS
 }
@@ -35,11 +37,13 @@ import utils.Utils.emptyString
 
 import java.time.LocalDate
 
-class ImportVatSpec extends SpecBase {
+class ImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "ImportVat view" should {
 
-    "display the correct title and guidance" in new Setup {
+    "display the correct title and guidance" in {
+      import Setup.*
+
       view.title() mustBe
         s"${messages("cf.account.vat.title")} - ${messages("service.name")} - GOV.UK"
 
@@ -63,7 +67,9 @@ class ImportVatSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val serviceUnavailableUrl: Option[String] = Option("service_unavailable_url")
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
@@ -85,6 +91,6 @@ class ImportVatSpec extends SpecBase {
 
     val viewModel: ImportVatViewModel = ImportVatViewModel(vatCertificatesForEoris, serviceUnavailableUrl)
 
-    val view: Document = Jsoup.parse(instanceOf[import_vat](application).apply(viewModel).body)
+    val view: Document = Jsoup.parse(instanceOf[import_vat](app).apply(viewModel).body)
   }
 }

--- a/test/views/import_vat/ImportVatSpec.scala
+++ b/test/views/import_vat/ImportVatSpec.scala
@@ -20,7 +20,6 @@ import config.AppConfig
 import models.EoriHistory
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -42,15 +41,15 @@ class ImportVatSpec extends SpecBase {
 
     "display the correct title and guidance" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.account.vat.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.account.vat.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementById("import-vat-certificates-heading").text() mustBe messages(app)("cf.account.vat.title")
+      view.getElementById("import-vat-certificates-heading").text() mustBe messages("cf.account.vat.title")
       view.getElementById("missing-certificates-guidance-heading").text() mustBe
-        messages(app)("cf.account.vat.older-certificates.heading")
+        messages("cf.account.vat.older-certificates.heading")
       view.getElementById("chief-guidance-heading").text() mustBe
-        messages(app)("cf.account.vat.chief.heading")
+        messages("cf.account.vat.chief.heading")
       view.getElementById("vat.support.message.heading").text() mustBe
-        messages(app)("cf.account.vat.support.heading")
+        messages("cf.account.vat.support.heading")
 
       view.html().contains("cf.account.vat.available-text")
       view.html().contains("cf.account.vat.your-certificates.heading")
@@ -65,23 +64,20 @@ class ImportVatSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application                      = application().build()
     val serviceUnavailableUrl: Option[String] = Option("service_unavailable_url")
 
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val eoriHistory: Seq[EoriHistory] = Seq(EoriHistory(EORI_NUMBER, None, None))
     val date: LocalDate               = LocalDate.now().withDayOfMonth(DAY_28)
 
     val currentCertificates: Seq[VatCertificatesByMonth] = Seq(
-      VatCertificatesByMonth(date.minusMonths(ONE_MONTH), Seq())(messages(app)),
-      VatCertificatesByMonth(date.minusMonths(TWO_MONTHS), Seq())(messages(app)),
-      VatCertificatesByMonth(date.minusMonths(THREE_MONTHS), Seq())(messages(app)),
-      VatCertificatesByMonth(date.minusMonths(FOUR_MONTHS), Seq())(messages(app)),
-      VatCertificatesByMonth(date.minusMonths(FIVE_MONTHS), Seq())(messages(app)),
-      VatCertificatesByMonth(date.minusMonths(SIX_MONTHS), Seq())(messages(app))
+      VatCertificatesByMonth(date.minusMonths(ONE_MONTH), Seq())(messages),
+      VatCertificatesByMonth(date.minusMonths(TWO_MONTHS), Seq())(messages),
+      VatCertificatesByMonth(date.minusMonths(THREE_MONTHS), Seq())(messages),
+      VatCertificatesByMonth(date.minusMonths(FOUR_MONTHS), Seq())(messages),
+      VatCertificatesByMonth(date.minusMonths(FIVE_MONTHS), Seq())(messages),
+      VatCertificatesByMonth(date.minusMonths(SIX_MONTHS), Seq())(messages)
     )
 
     val vatCertificatesForEoris: Seq[VatCertificatesForEori] =
@@ -89,6 +85,6 @@ class ImportVatSpec extends SpecBase {
 
     val viewModel: ImportVatViewModel = ImportVatViewModel(vatCertificatesForEoris, serviceUnavailableUrl)
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[import_vat].apply(viewModel).body)
+    val view: Document = Jsoup.parse(application.injector.instanceOf[import_vat].apply(viewModel).body)
   }
 }

--- a/test/views/import_vat/ImportVatSpec.scala
+++ b/test/views/import_vat/ImportVatSpec.scala
@@ -85,6 +85,6 @@ class ImportVatSpec extends SpecBase {
 
     val viewModel: ImportVatViewModel = ImportVatViewModel(vatCertificatesForEoris, serviceUnavailableUrl)
 
-    val view: Document = Jsoup.parse(application.injector.instanceOf[import_vat].apply(viewModel).body)
+    val view: Document = Jsoup.parse(instanceOf[import_vat](application).apply(viewModel).body)
   }
 }

--- a/test/views/import_vat/ImportVatSpec.scala
+++ b/test/views/import_vat/ImportVatSpec.scala
@@ -41,9 +41,7 @@ class ImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
 
   "ImportVat view" should {
 
-    "display the correct title and guidance" in {
-      import Setup.*
-
+    "display the correct title and guidance" in new Setup {
       view.title() mustBe
         s"${messages("cf.account.vat.title")} - ${messages("service.name")} - GOV.UK"
 
@@ -69,7 +67,7 @@ class ImportVatSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val serviceUnavailableUrl: Option[String] = Option("service_unavailable_url")
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")

--- a/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
+++ b/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
@@ -25,22 +25,25 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import utils.CommonTestData._
+import utils.CommonTestData.*
 import utils.SpecBase
 import utils.Utils.emptyString
 import views.html.postponed_vat.collapsible_statement_group
 
-class CollapsibleStatementGroupSpec extends SpecBase {
+class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "view" should {
 
     "display correct contents" when {
 
-      "Postponed Vat Statement files are present and source is only CDS" in new Setup {
+      "Postponed Vat Statement files are present and source is only CDS" in {
         val viewDoc: Document =
           view(certificateFiles, downloadLinkMessage, downloadAriaLabel, Some(missingFileMessage), CDS, period)
 
@@ -48,7 +51,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
         shouldContainDownloadLinkPVATStatementSection(viewDoc)
       }
 
-      "Postponed Vat Statement files are present and source include CHIEF" in new Setup {
+      "Postponed Vat Statement files are present and source include CHIEF" in {
         val viewDoc: Document = view(
           certificateFiles,
           downloadLinkMessage,
@@ -63,14 +66,14 @@ class CollapsibleStatementGroupSpec extends SpecBase {
         shouldContainDownloadLinkPVATStatementSection(viewDoc, isCDSOnly = false)
       }
 
-      "there are no Postponed Vat Statement files and source is only CDS" in new Setup {
+      "there are no Postponed Vat Statement files and source is only CDS" in {
         val viewDoc: Document =
           view(Seq(), downloadLinkMessage, downloadAriaLabel, Some(missingFileMessage), CDS, period)
 
         shouldNotDisplayAnyContent(viewDoc)
       }
 
-      "there are no Postponed Vat Statement files and source include CHIEF" in new Setup {
+      "there are no Postponed Vat Statement files and source include CHIEF" in {
         val viewDoc: Document = view(
           Seq(),
           downloadLinkMessage,
@@ -84,7 +87,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
         shouldNotDisplayAnyContent(viewDoc)
       }
 
-      "Postponed Vat Statement files are present, source is only CDS and contains missingFileMessage" in new Setup {
+      "Postponed Vat Statement files are present, source is only CDS and contains missingFileMessage" in {
         val viewDoc: Document = view(
           certificateFiles,
           downloadLinkMessage,
@@ -98,7 +101,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
         shouldContainMissingFileMessageGuidance(viewDoc, missingFileMessage, CHIEF, period)
       }
 
-      "Postponed Vat Statement files are present, source is only CDS and has no missingFileMessage" in new Setup {
+      "Postponed Vat Statement files are present, source is only CDS and has no missingFileMessage" in {
         val viewDoc: Document =
           view(certificateFiles, downloadLinkMessage, downloadAriaLabel, None, CHIEF, period, isCdsOnly = false)
 
@@ -148,7 +151,9 @@ class CollapsibleStatementGroupSpec extends SpecBase {
     if (isCDSOnly) ddElements.size() mustBe 1 else ddElements.size() mustBe 2
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
@@ -176,7 +181,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
       period: String,
       isCdsOnly: Boolean = true
     ): Document = Jsoup.parse(
-      instanceOf[collapsible_statement_group](application)
+      instanceOf[collapsible_statement_group](app)
         .apply(
           certificateFiles,
           downloadLinkMessage,

--- a/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
+++ b/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
@@ -25,7 +25,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -121,8 +121,8 @@ class CollapsibleStatementGroupSpec extends SpecBase {
 
     val visuallyHiddenElements = viewDoc.getElementsByClass("govuk-visually-hidden")
 
-    firstSpanElement mustBe msgs(missingFileMessage, paymentMethodSource)
-    secondSpanElement mustBe msgs("cf.common.not-available-screen-reader-cds", period)
+    firstSpanElement mustBe messages(missingFileMessage, paymentMethodSource)
+    secondSpanElement mustBe messages("cf.common.not-available-screen-reader-cds", period)
 
     visuallyHiddenElements.size() mustBe 2
   }
@@ -149,9 +149,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application().build()
 
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val certificateFiles: Seq[PostponedVatStatementFile] = Seq(
@@ -178,7 +176,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
       period: String,
       isCdsOnly: Boolean = true
     ): Document = Jsoup.parse(
-      app.injector
+      application.injector
         .instanceOf[collapsible_statement_group]
         .apply(
           certificateFiles,

--- a/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
+++ b/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
@@ -176,8 +176,7 @@ class CollapsibleStatementGroupSpec extends SpecBase {
       period: String,
       isCdsOnly: Boolean = true
     ): Document = Jsoup.parse(
-      application.injector
-        .instanceOf[collapsible_statement_group]
+      instanceOf[collapsible_statement_group](application)
         .apply(
           certificateFiles,
           downloadLinkMessage,

--- a/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
+++ b/test/views/postponed_vat/CollapsibleStatementGroupSpec.scala
@@ -37,13 +37,11 @@ import views.html.postponed_vat.collapsible_statement_group
 
 class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "view" should {
 
     "display correct contents" when {
 
-      "Postponed Vat Statement files are present and source is only CDS" in {
+      "Postponed Vat Statement files are present and source is only CDS" in new Setup {
         val viewDoc: Document =
           view(certificateFiles, downloadLinkMessage, downloadAriaLabel, Some(missingFileMessage), CDS, period)
 
@@ -51,7 +49,7 @@ class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
         shouldContainDownloadLinkPVATStatementSection(viewDoc)
       }
 
-      "Postponed Vat Statement files are present and source include CHIEF" in {
+      "Postponed Vat Statement files are present and source include CHIEF" in new Setup {
         val viewDoc: Document = view(
           certificateFiles,
           downloadLinkMessage,
@@ -66,14 +64,14 @@ class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
         shouldContainDownloadLinkPVATStatementSection(viewDoc, isCDSOnly = false)
       }
 
-      "there are no Postponed Vat Statement files and source is only CDS" in {
+      "there are no Postponed Vat Statement files and source is only CDS" in new Setup {
         val viewDoc: Document =
           view(Seq(), downloadLinkMessage, downloadAriaLabel, Some(missingFileMessage), CDS, period)
 
         shouldNotDisplayAnyContent(viewDoc)
       }
 
-      "there are no Postponed Vat Statement files and source include CHIEF" in {
+      "there are no Postponed Vat Statement files and source include CHIEF" in new Setup {
         val viewDoc: Document = view(
           Seq(),
           downloadLinkMessage,
@@ -87,7 +85,7 @@ class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
         shouldNotDisplayAnyContent(viewDoc)
       }
 
-      "Postponed Vat Statement files are present, source is only CDS and contains missingFileMessage" in {
+      "Postponed Vat Statement files are present, source is only CDS and contains missingFileMessage" in new Setup {
         val viewDoc: Document = view(
           certificateFiles,
           downloadLinkMessage,
@@ -101,7 +99,7 @@ class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
         shouldContainMissingFileMessageGuidance(viewDoc, missingFileMessage, CHIEF, period)
       }
 
-      "Postponed Vat Statement files are present, source is only CDS and has no missingFileMessage" in {
+      "Postponed Vat Statement files are present, source is only CDS and has no missingFileMessage" in new Setup {
         val viewDoc: Document =
           view(certificateFiles, downloadLinkMessage, downloadAriaLabel, None, CHIEF, period, isCdsOnly = false)
 
@@ -153,7 +151,7 @@ class CollapsibleStatementGroupSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 

--- a/test/views/postponed_vat/CurrentStatementRowSpec.scala
+++ b/test/views/postponed_vat/CurrentStatementRowSpec.scala
@@ -153,7 +153,7 @@ class CurrentStatementRowSpec extends SpecBase {
     val visuallyHiddenMsg = "Not available visually hidden"
 
     def view(currentStatementRow: CurrentStatementRow): Document =
-      Jsoup.parse(application.injector.instanceOf[current_statement_row].apply(currentStatementRow).body)
+      Jsoup.parse(instanceOf[current_statement_row](application).apply(currentStatementRow).body)
 
     implicit val mockDateTimeService: DateTimeService = mock[DateTimeService]
 

--- a/test/views/postponed_vat/CurrentStatementRowSpec.scala
+++ b/test/views/postponed_vat/CurrentStatementRowSpec.scala
@@ -43,13 +43,11 @@ import java.time.{LocalDate, LocalDateTime}
 
 class CurrentStatementRowSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "view" should {
 
     "display correct contents" when {
 
-      "collapsibleStatementGroupRows are empty but contains dd row for CDS and CHIEF" in {
+      "collapsibleStatementGroupRows are empty but contains dd row for CDS and CHIEF" in new Setup {
 
         val cdsDDRow: DDRow   = DDRow(notAvailableMsg = notAvailableMsg, visuallyHiddenMsg = visuallyHiddenMsg)
         val chiefDDRow: DDRow = DDRow(notAvailableMsg = notAvailableMsg, visuallyHiddenMsg = visuallyHiddenMsg)
@@ -65,7 +63,7 @@ class CurrentStatementRowSpec extends SpecBase with GuiceOneAppPerSuite {
         shouldDisplayCHIEFDDRow(viewDoc, notAvailableMsg, visuallyHiddenMsg)
       }
 
-      "collapsibleStatementGroupRows are present but no dd row for CDS and CHIEF" in {
+      "collapsibleStatementGroupRows are present but no dd row for CDS and CHIEF" in new Setup {
 
         val statementRow: CurrentStatementRow = CurrentStatementRow(
           periodId,
@@ -148,7 +146,7 @@ class CurrentStatementRowSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val periodId     = "test_id"

--- a/test/views/postponed_vat/CurrentStatementRowSpec.scala
+++ b/test/views/postponed_vat/CurrentStatementRowSpec.scala
@@ -25,12 +25,13 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import services.DateTimeService
-import utils.CommonTestData._
+import utils.CommonTestData.*
 import utils.SpecBase
 import utils.Utils.emptyString
 import viewmodels.{CollapsibleStatementGroupRow, CurrentStatementRow, DDRow}
@@ -40,13 +41,15 @@ import views.html.postponed_vat.{collapsible_statement_group, current_statement_
 
 import java.time.{LocalDate, LocalDateTime}
 
-class CurrentStatementRowSpec extends SpecBase {
+class CurrentStatementRowSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "view" should {
 
     "display correct contents" when {
 
-      "collapsibleStatementGroupRows are empty but contains dd row for CDS and CHIEF" in new Setup {
+      "collapsibleStatementGroupRows are empty but contains dd row for CDS and CHIEF" in {
 
         val cdsDDRow: DDRow   = DDRow(notAvailableMsg = notAvailableMsg, visuallyHiddenMsg = visuallyHiddenMsg)
         val chiefDDRow: DDRow = DDRow(notAvailableMsg = notAvailableMsg, visuallyHiddenMsg = visuallyHiddenMsg)
@@ -62,7 +65,7 @@ class CurrentStatementRowSpec extends SpecBase {
         shouldDisplayCHIEFDDRow(viewDoc, notAvailableMsg, visuallyHiddenMsg)
       }
 
-      "collapsibleStatementGroupRows are present but no dd row for CDS and CHIEF" in new Setup {
+      "collapsibleStatementGroupRows are present but no dd row for CDS and CHIEF" in {
 
         val statementRow: CurrentStatementRow = CurrentStatementRow(
           periodId,
@@ -143,7 +146,9 @@ class CurrentStatementRowSpec extends SpecBase {
       "September 2023 CDS statement - PDF (1KB)"
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val periodId     = "test_id"
@@ -153,7 +158,7 @@ class CurrentStatementRowSpec extends SpecBase {
     val visuallyHiddenMsg = "Not available visually hidden"
 
     def view(currentStatementRow: CurrentStatementRow): Document =
-      Jsoup.parse(instanceOf[current_statement_row](application).apply(currentStatementRow).body)
+      Jsoup.parse(instanceOf[current_statement_row](app).apply(currentStatementRow).body)
 
     implicit val mockDateTimeService: DateTimeService = mock[DateTimeService]
 

--- a/test/views/postponed_vat/CurrentStatementRowSpec.scala
+++ b/test/views/postponed_vat/CurrentStatementRowSpec.scala
@@ -25,7 +25,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -144,9 +144,6 @@ class CurrentStatementRowSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application().build()
-
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val periodId     = "test_id"
@@ -156,7 +153,7 @@ class CurrentStatementRowSpec extends SpecBase {
     val visuallyHiddenMsg = "Not available visually hidden"
 
     def view(currentStatementRow: CurrentStatementRow): Document =
-      Jsoup.parse(app.injector.instanceOf[current_statement_row].apply(currentStatementRow).body)
+      Jsoup.parse(application.injector.instanceOf[current_statement_row].apply(currentStatementRow).body)
 
     implicit val mockDateTimeService: DateTimeService = mock[DateTimeService]
 

--- a/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
+++ b/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
@@ -88,8 +88,7 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
       downloadAriaLabel: String,
       period: String
     ): Document = Jsoup.parse(
-      application.injector
-        .instanceOf[download_link_pvat_statement]
+      instanceOf[download_link_pvat_statement](application)
         .apply(fileFormat, certificateFiles, downloadLinkMessage, downloadAriaLabel, period)
         .body
     )

--- a/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
+++ b/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
@@ -25,7 +25,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -65,8 +64,6 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application().build()
-
     val fileFormat: FileFormat                           = Pdf
     val certificateFiles: Seq[PostponedVatStatementFile] = Seq(
       PostponedVatStatementFile(
@@ -82,7 +79,6 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
     val downloadAriaLabel   = "cf.account.pvat.aria.download-link"
     val period              = "test_period"
 
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     def view(
@@ -92,7 +88,7 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
       downloadAriaLabel: String,
       period: String
     ): Document = Jsoup.parse(
-      app.injector
+      application.injector
         .instanceOf[download_link_pvat_statement]
         .apply(fileFormat, certificateFiles, downloadLinkMessage, downloadAriaLabel, period)
         .body

--- a/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
+++ b/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
@@ -37,13 +37,11 @@ import views.html.postponed_vat.download_link_pvat_statement
 
 class DownloadLinkPvatStatementSpec extends SpecBase with GuiceOneAppPerSuite {
 
-  import Setup.*
-
   "view" should {
 
     "display correct contents" when {
 
-      "Postponed Vat statement files are present" in {
+      "Postponed Vat statement files are present" in new Setup {
         val viewDoc: Document = view(Pdf, certificateFiles, downloadLinkMessage, downloadAriaLabel, period)
 
         val elements: Elements = viewDoc.getElementsByAttribute("href")
@@ -56,7 +54,7 @@ class DownloadLinkPvatStatementSpec extends SpecBase with GuiceOneAppPerSuite {
           "test_period CDS statement - PDF (1KB)"
       }
 
-      "there is no Postponed Vat statement files" in {
+      "there is no Postponed Vat statement files" in new Setup {
         val viewDoc: Document = view(Pdf, Seq(), downloadLinkMessage, downloadAriaLabel, period)
 
         viewDoc.body().html() mustBe empty
@@ -69,7 +67,7 @@ class DownloadLinkPvatStatementSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     val fileFormat: FileFormat                           = Pdf
     val certificateFiles: Seq[PostponedVatStatementFile] = Seq(
       PostponedVatStatementFile(

--- a/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
+++ b/test/views/postponed_vat/DownloadLinkPvatStatementSpec.scala
@@ -25,21 +25,25 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import org.scalatest.matchers.must.Matchers.mustBe
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import utils.CommonTestData._
+import utils.CommonTestData.*
 import utils.SpecBase
 import utils.Utils.emptyString
 import views.html.postponed_vat.download_link_pvat_statement
 
-class DownloadLinkPvatStatementSpec extends SpecBase {
+class DownloadLinkPvatStatementSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  import Setup.*
 
   "view" should {
 
     "display correct contents" when {
 
-      "Postponed Vat statement files are present" in new Setup {
+      "Postponed Vat statement files are present" in {
         val viewDoc: Document = view(Pdf, certificateFiles, downloadLinkMessage, downloadAriaLabel, period)
 
         val elements: Elements = viewDoc.getElementsByAttribute("href")
@@ -52,7 +56,7 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
           "test_period CDS statement - PDF (1KB)"
       }
 
-      "there is no Postponed Vat statement files" in new Setup {
+      "there is no Postponed Vat statement files" in {
         val viewDoc: Document = view(Pdf, Seq(), downloadLinkMessage, downloadAriaLabel, period)
 
         viewDoc.body().html() mustBe empty
@@ -63,7 +67,9 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
     }
   }
 
-  trait Setup {
+  override def fakeApplication(): Application = applicationBuilder.build()
+
+  object Setup {
     val fileFormat: FileFormat                           = Pdf
     val certificateFiles: Seq[PostponedVatStatementFile] = Seq(
       PostponedVatStatementFile(
@@ -88,7 +94,7 @@ class DownloadLinkPvatStatementSpec extends SpecBase {
       downloadAriaLabel: String,
       period: String
     ): Document = Jsoup.parse(
-      instanceOf[download_link_pvat_statement](application)
+      instanceOf[download_link_pvat_statement](app)
         .apply(fileFormat, certificateFiles, downloadLinkMessage, downloadAriaLabel, period)
         .body
     )

--- a/test/views/securities/SecurityStatementsSpec.scala
+++ b/test/views/securities/SecurityStatementsSpec.scala
@@ -26,7 +26,7 @@ import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.Application
+
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -37,6 +37,7 @@ import utils.SpecBase
 import viewmodels.SecurityStatementsViewModel
 import views.helpers.Formatters.{dateAsDayMonthAndYear, dateAsMonthAndYear, fileSize}
 import views.html.securities.security_statements
+import play.api.Application
 
 import java.time.LocalDate
 
@@ -48,44 +49,44 @@ class SecurityStatementsSpec extends SpecBase {
 
       "statements are available" in new Setup {
         val view: Document =
-          Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModelWithStatements).body)
+          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithStatements).body)
 
-        commonGuidanceText(view, app)
+        commonGuidanceText(view, application)
 
         view.text().contains("PDF") mustBe true
         view.text().contains("CSV") mustBe true
 
-        view.text().contains(messages(app)("cf.security-statements.eom")) mustBe true
+        view.text().contains(messages("cf.security-statements.eom")) mustBe true
       }
 
       "statements are empty" in new Setup {
         val view: Document =
-          Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModelWithNoStatements).body)
+          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithNoStatements).body)
 
-        commonGuidanceText(view, app)
+        commonGuidanceText(view, application)
 
-        view.text().contains(messages(app)("cf.security-statements.eom")) mustBe false
+        view.text().contains(messages("cf.security-statements.eom")) mustBe false
       }
 
       "current statements are empty" in new Setup {
         val view: Document =
-          Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModelWithNoCurrentStatements).body)
+          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithNoCurrentStatements).body)
 
-        commonGuidanceText(view, app)
+        commonGuidanceText(view, application)
 
-        view.getElementById("no-statements").text() mustBe messages(app)("cf.security-statements.no-statements")
-        view.text().contains(messages(app)("cf.security-statements.eom")) mustBe false
+        view.getElementById("no-statements").text() mustBe messages("cf.security-statements.no-statements")
+        view.text().contains(messages("cf.security-statements.eom")) mustBe false
         view.text().contains("PDF") mustBe false
         view.text().contains("CSV") mustBe false
       }
 
       "statements have Pdfs but not Csvs" in new Setup {
         val view: Document =
-          Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModelWithPdfStatementsOnly).body)
+          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithPdfStatementsOnly).body)
 
-        commonGuidanceText(view, app)
+        commonGuidanceText(view, application)
 
-        view.text().contains(messages(app)("cf.security-statements.eom")) mustBe false
+        view.text().contains(messages("cf.security-statements.eom")) mustBe false
 
         view.text().contains("PDF") mustBe true
         view.text().contains("CSV") mustBe false
@@ -93,7 +94,7 @@ class SecurityStatementsSpec extends SpecBase {
         view
           .text()
           .contains(
-            messages(app)(
+            messages(
               "cf.security-statements.requested.period",
               dateAsDayMonthAndYear(statementsByPeriodForPdf.startDate),
               dateAsDayMonthAndYear(statementsByPeriodForPdf.endDate)
@@ -103,11 +104,11 @@ class SecurityStatementsSpec extends SpecBase {
 
       "statements have Csvs but not Pdfs" in new Setup {
         val view: Document =
-          Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModelWithCsvStatementsOnly).body)
+          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithCsvStatementsOnly).body)
 
-        commonGuidanceText(view, app)
+        commonGuidanceText(view, application)
 
-        view.text().contains(messages(app)("cf.security-statements.eom")) mustBe true
+        view.text().contains(messages("cf.security-statements.eom")) mustBe true
 
         view.text().contains("PDF") mustBe false
         view.text().contains("CSV") mustBe true
@@ -117,7 +118,7 @@ class SecurityStatementsSpec extends SpecBase {
         view
           .text()
           .contains(
-            messages(app)(
+            messages(
               "cf.security-statements.requested.download-link.aria-text.csv",
               Csv,
               dateAsMonthAndYear(statementsByPeriodForCsv.startDate),
@@ -129,24 +130,27 @@ class SecurityStatementsSpec extends SpecBase {
       "statements have Csv(with Unknown file type) but not Pdfs" in new Setup {
         val view: Document =
           Jsoup.parse(
-            app.injector.instanceOf[security_statements].apply(viewModelWithCsvStatementsOnlyWithUnknownFileType).body
+            application.injector
+              .instanceOf[security_statements]
+              .apply(viewModelWithCsvStatementsOnlyWithUnknownFileType)
+              .body
           )
 
-        commonGuidanceText(view, app)
+        commonGuidanceText(view, application)
 
         view.text().contains("CSV") mustBe true
         val unavailableCsvElem: Element   = view.getElementById("statements-list-0-row-0-unavailable-csv")
         val screenReaderElement: Elements = unavailableCsvElem.getElementsByClass("govuk-visually-hidden")
 
         screenReaderElement.text() mustBe
-          messages(app)(
+          messages(
             "cf.security-statements.screen-reader.unavailable.month.year",
             Csv,
             dateAsMonthAndYear(statementsByPeriodForCsvWithUnknownFileType.startDate)
           )
 
         view.text().contains(dateAsMonthAndYear(statementsByPeriodForCsvWithUnknownFileType.startDate)) mustBe true
-        view.text().contains(messages(app)("cf.unavailable")) mustBe true
+        view.text().contains(messages("cf.unavailable")) mustBe true
       }
 
       "statements are available and EORI header is present" in new Setup {
@@ -156,9 +160,9 @@ class SecurityStatementsSpec extends SpecBase {
         )
 
         val viewModel: SecurityStatementsViewModel = SecurityStatementsViewModel(multipleEoris)
-        val view: Document                         = Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModel).body)
+        val view: Document                         = Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModel).body)
 
-        view.text().contains(messages(app)("cf.account.details.previous-eori", "testEori"))
+        view.text().contains(messages("cf.account.details.previous-eori", "testEori"))
       }
     }
 
@@ -169,7 +173,7 @@ class SecurityStatementsSpec extends SpecBase {
       )
 
       val viewModel: SecurityStatementsViewModel = SecurityStatementsViewModel(statementsWithMixedCurrent)
-      val view: Document                         = Jsoup.parse(app.injector.instanceOf[security_statements].apply(viewModel).body)
+      val view: Document                         = Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModel).body)
 
       view.text().contains("PDF") mustBe true
       view.text().contains("CSV") mustBe false
@@ -178,51 +182,47 @@ class SecurityStatementsSpec extends SpecBase {
 
   private def commonGuidanceText(view: Document, app: Application): Assertion = {
     view.title() mustBe
-      s"${messages(app)("cf.security-statements.title")} - ${messages(app)("service.name")} - GOV.UK"
-    view.getElementsByTag("h1").text() mustBe messages(app)("cf.security-statements.title")
+      s"${messages("cf.security-statements.title")} - ${messages("service.name")} - GOV.UK"
+    view.getElementsByTag("h1").text() mustBe messages("cf.security-statements.title")
 
     view.getElementById("missing-documents-guidance-heading").text mustBe
-      messages(app)(
+      messages(
         "cf.common.missing-documents-guidance.heading",
-        messages(app)("cf.common.missing-documents-guidance.statement")
+        messages("cf.common.missing-documents-guidance.statement")
       )
 
     view.getElementById("missing-documents-guidance-chiefHeading").text mustBe
-      messages(app)(
+      messages(
         "cf.common.missing-documents-guidance.chiefHeading",
-        messages(app)("cf.common.missing-documents-guidance.statements")
+        messages("cf.common.missing-documents-guidance.statements")
       )
 
     view.getElementById("missing-documents-guidance-text1").text mustBe
-      messages(app)(
+      messages(
         "cf.common.missing-documents-guidance.text1",
-        messages(app)("cf.common.missing-documents-guidance.statements")
+        messages("cf.common.missing-documents-guidance.statements")
       )
 
     view.getElementById("missing-documents-guidance-certificatesHeading").text mustBe
-      messages(app)(
+      messages(
         "cf.common.missing-documents-guidance.subHeading",
-        messages(app)("cf.common.missing-documents-guidance.statements")
+        messages("cf.common.missing-documents-guidance.statements")
       )
 
     view.getElementById("missing-documents-guidance-text2").text mustBe
-      messages(app)(
+      messages(
         "cf.common.missing-documents-guidance.text2",
-        messages(app)("cf.common.missing-documents-guidance.statements")
+        messages("cf.common.missing-documents-guidance.statements")
       )
 
     view.getElementById("historic-statement-request").text() mustBe
-      messages(app)("cf.security-statements.historic.description")
+      messages("cf.security-statements.historic.description")
 
     view.getElementById("historic-statement-request-link").text() mustBe
-      messages(app)("cf.security-statements.historic.request")
+      messages("cf.security-statements.historic.request")
   }
 
   trait Setup {
-    val app: Application = application().build()
-
-    implicit val appConfig: AppConfig                         = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages                                = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val date: LocalDate = LocalDate.now().withDayOfMonth(DAY_28)

--- a/test/views/securities/SecurityStatementsSpec.scala
+++ b/test/views/securities/SecurityStatementsSpec.scala
@@ -49,7 +49,7 @@ class SecurityStatementsSpec extends SpecBase {
 
       "statements are available" in new Setup {
         val view: Document =
-          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithStatements).body)
+          Jsoup.parse(instanceOf[security_statements](application).apply(viewModelWithStatements).body)
 
         commonGuidanceText(view, application)
 
@@ -61,7 +61,7 @@ class SecurityStatementsSpec extends SpecBase {
 
       "statements are empty" in new Setup {
         val view: Document =
-          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithNoStatements).body)
+          Jsoup.parse(instanceOf[security_statements](application).apply(viewModelWithNoStatements).body)
 
         commonGuidanceText(view, application)
 
@@ -70,7 +70,7 @@ class SecurityStatementsSpec extends SpecBase {
 
       "current statements are empty" in new Setup {
         val view: Document =
-          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithNoCurrentStatements).body)
+          Jsoup.parse(instanceOf[security_statements](application).apply(viewModelWithNoCurrentStatements).body)
 
         commonGuidanceText(view, application)
 
@@ -82,7 +82,7 @@ class SecurityStatementsSpec extends SpecBase {
 
       "statements have Pdfs but not Csvs" in new Setup {
         val view: Document =
-          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithPdfStatementsOnly).body)
+          Jsoup.parse(instanceOf[security_statements](application).apply(viewModelWithPdfStatementsOnly).body)
 
         commonGuidanceText(view, application)
 
@@ -104,7 +104,7 @@ class SecurityStatementsSpec extends SpecBase {
 
       "statements have Csvs but not Pdfs" in new Setup {
         val view: Document =
-          Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModelWithCsvStatementsOnly).body)
+          Jsoup.parse(instanceOf[security_statements](application).apply(viewModelWithCsvStatementsOnly).body)
 
         commonGuidanceText(view, application)
 
@@ -130,8 +130,7 @@ class SecurityStatementsSpec extends SpecBase {
       "statements have Csv(with Unknown file type) but not Pdfs" in new Setup {
         val view: Document =
           Jsoup.parse(
-            application.injector
-              .instanceOf[security_statements]
+            instanceOf[security_statements](application)
               .apply(viewModelWithCsvStatementsOnlyWithUnknownFileType)
               .body
           )
@@ -160,7 +159,7 @@ class SecurityStatementsSpec extends SpecBase {
         )
 
         val viewModel: SecurityStatementsViewModel = SecurityStatementsViewModel(multipleEoris)
-        val view: Document                         = Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModel).body)
+        val view: Document                         = Jsoup.parse(instanceOf[security_statements](application).apply(viewModel).body)
 
         view.text().contains(messages("cf.account.details.previous-eori", "testEori"))
       }
@@ -173,7 +172,7 @@ class SecurityStatementsSpec extends SpecBase {
       )
 
       val viewModel: SecurityStatementsViewModel = SecurityStatementsViewModel(statementsWithMixedCurrent)
-      val view: Document                         = Jsoup.parse(application.injector.instanceOf[security_statements].apply(viewModel).body)
+      val view: Document                         = Jsoup.parse(instanceOf[security_statements](application).apply(viewModel).body)
 
       view.text().contains("PDF") mustBe true
       view.text().contains("CSV") mustBe false

--- a/test/views/securities/SecurityStatementsSpec.scala
+++ b/test/views/securities/SecurityStatementsSpec.scala
@@ -41,13 +41,12 @@ import play.api.Application
 import java.time.LocalDate
 
 class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
-  import Setup.*
 
   "view" should {
 
     "display correct title and guidance" when {
 
-      "statements are available" in {
+      "statements are available" in new Setup {
         val view: Document =
           Jsoup.parse(instanceOf[security_statements](app).apply(viewModelWithStatements).body)
 
@@ -59,7 +58,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
         view.text().contains(messages("cf.security-statements.eom")) mustBe true
       }
 
-      "statements are empty" in {
+      "statements are empty" in new Setup {
         val view: Document =
           Jsoup.parse(instanceOf[security_statements](app).apply(viewModelWithNoStatements).body)
 
@@ -68,7 +67,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
         view.text().contains(messages("cf.security-statements.eom")) mustBe false
       }
 
-      "current statements are empty" in {
+      "current statements are empty" in new Setup {
         val view: Document =
           Jsoup.parse(instanceOf[security_statements](app).apply(viewModelWithNoCurrentStatements).body)
 
@@ -80,7 +79,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
         view.text().contains("CSV") mustBe false
       }
 
-      "statements have Pdfs but not Csvs" in {
+      "statements have Pdfs but not Csvs" in new Setup {
         val view: Document =
           Jsoup.parse(instanceOf[security_statements](app).apply(viewModelWithPdfStatementsOnly).body)
 
@@ -102,7 +101,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
           ) mustBe true
       }
 
-      "statements have Csvs but not Pdfs" in {
+      "statements have Csvs but not Pdfs" in new Setup {
         val view: Document =
           Jsoup.parse(instanceOf[security_statements](app).apply(viewModelWithCsvStatementsOnly).body)
 
@@ -127,7 +126,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
           ) mustBe true
       }
 
-      "statements have Csv(with Unknown file type) but not Pdfs" in {
+      "statements have Csv(with Unknown file type) but not Pdfs" in new Setup {
         val view: Document =
           Jsoup.parse(
             instanceOf[security_statements](app)
@@ -152,7 +151,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
         view.text().contains(messages("cf.unavailable")) mustBe true
       }
 
-      "statements are available and EORI header is present" in {
+      "statements are available and EORI header is present" in new Setup {
         val multipleEoris: Seq[SecurityStatementsForEori] = Seq(
           securityStatementsForEori,
           securityStatementsForEori.copy(eoriHistory = EoriHistory("testEori", None, None))
@@ -165,7 +164,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
       }
     }
 
-    "return PDF statements when CSV statements are empty" in {
+    "return PDF statements when CSV statements are empty" in new Setup {
       val statementsWithMixedCurrent: Seq[SecurityStatementsForEori] = Seq(
         securityStatementsForEori.copy(currentStatements = Seq.empty),
         securityStatementsForEori.copy(currentStatements = Seq(statementsByPeriodForPdf))
@@ -223,7 +222,7 @@ class SecurityStatementsSpec extends SpecBase with GuiceOneAppPerSuite {
 
   override def fakeApplication(): Application = applicationBuilder.build()
 
-  object Setup {
+  trait Setup {
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val date: LocalDate = LocalDate.now().withDayOfMonth(DAY_28)


### PR DESCRIPTION
Description - Update unit tests to make use of common instance of ApConfig, Messages and Application (one Application per Test Suites wherever possible)

Below has been done as part of this PR

- [x] update tests
- [x] use of standard trait GuiceOneAppPerSuite wherever possible to make use of a single app for the entire suite
- [x] update SpecBase to contain the vals for AppConfig, Messages
- [x] add val to create the default GuiceApplicationBuilder
- [x] create common instanceOf method to create the instance of provided class

- [x] scala formatting for the files where relevant changes have been made
- [x] minor refactoring