### PR TITLE
MMCA-5312: Removing trailing space from link

### DIFF
--- a/app/views/components/link.scala.html
+++ b/app/views/components/link.scala.html
@@ -32,13 +32,9 @@
 )(implicit messages: Messages)
 
 @link = {
-  <a @{linkId.fold(emptyString)(id => s"id=$id")} class="@linkClass" href="@location">
-    <span>@Html(messages(linkMessage))</span>
-
-    @if(ariaLabel.isDefined){
+  <a @{linkId.fold(emptyString)(id => s"id=$id")} class="@linkClass" href="@location"><span>@Html(messages(linkMessage))</span>@if(ariaLabel.isDefined){
       <span class="govuk-visually-hidden">@ariaLabel</span>
-    }
-  </a>@if(linkSentence){@period}
+    }</a>@if(linkSentence){@period}
 }
 
 @if(pWrapped) {


### PR DESCRIPTION
the line for the hyperlink "your requested statements are now available" extends beyond the word certificates into the space between words. This PR rectifies that so that the line is only under the hyperlinked words.