### PR TITLE
MMCA-5351: Amend accessibility issues on PVAT statements page

### DIFF
--- a/app/viewmodels/ImportVatViewModel.scala
+++ b/app/viewmodels/ImportVatViewModel.scala
@@ -140,7 +140,8 @@ object ImportVatViewModel {
         linkComponent(
           "cf.account.vat.older-certificates.description.link",
           location = serviceUnavailableUrl.getOrElse(emptyString),
-          preLinkMessage = Some("cf.account.vat.older-certificates.description.1")
+          preLinkMessage = Some("cf.account.vat.older-certificates.description.1"),
+          linkSentence = true
         )
       )
     )
@@ -159,7 +160,8 @@ object ImportVatViewModel {
         linkComponent(
           appConfig.c79EmailAddress,
           location = appConfig.c79EmailAddressHref,
-          preLinkMessage = Some("cf.account.vat.older-certificates.description.2")
+          preLinkMessage = Some("cf.account.vat.older-certificates.description.2"),
+          linkSentence = true
         )
       )
     )
@@ -174,20 +176,13 @@ object ImportVatViewModel {
         msg = "cf.account.vat.support.heading",
         classes = "govuk-heading-m govuk-!-margin-top-2"
       ),
-      paragraph = Some(
-        pComponent(
-          message = "cf.account.vat.support.message",
-          classes = "govuk-body govuk-!-margin-bottom-9",
-          tabLink = Some(
-            hmrcNewTabLinkComponent(
-              NewTabLink(
-                language = Some(messages.lang.toString),
-                classList = Some("govuk-link"),
-                href = Some(appConfig.viewVatAccountSupportLink),
-                text = messages("cf.account.vat.support.link")
-              )
-            )
-          )
+      link = Some(
+        linkComponent(
+          preLinkMessage = Some("cf.account.vat.support.message"),
+          linkMessage = "cf.account.vat.support.link",
+          location = appConfig.viewVatAccountSupportLink,
+          openInNewTab = true,
+          linkSentence = true
         )
       )
     )

--- a/app/viewmodels/PostponedVatViewModel.scala
+++ b/app/viewmodels/PostponedVatViewModel.scala
@@ -172,7 +172,8 @@ object PostponedVatViewModel {
     val link = linkComponent.apply(
       "cf.account.pvat.older-statements.description.link",
       location = serviceUnavailableUrl.getOrElse(emptyString),
-      preLinkMessage = Some("cf.account.pvat.older-statements.description.2")
+      preLinkMessage = Some("cf.account.pvat.older-statements.description.2"),
+      linkSentence = true
     )
 
     GuidanceRow(
@@ -191,7 +192,9 @@ object PostponedVatViewModel {
     val link = linkComponent.apply(
       pvEmail.emailAddress,
       location = pvEmail.emailAddressHref,
-      preLinkMessage = Some("cf.account.pvat.older-statements.description.3")
+      preLinkMessage = Some("cf.account.pvat.older-statements.description.3"),
+      linkSentence
+       = true
     )
 
     GuidanceRow(
@@ -214,9 +217,10 @@ object PostponedVatViewModel {
       msgs("cf.account.pvat.support.link"),
       location = viewVatAccountSupportLink,
       preLinkMessage = Some("cf.account.pvat.support.message"),
-      postLinkMessage = Some(period),
       pId = Some("pvat.support.message"),
-      pClass = "govuk-body govuk-!-margin-bottom-9"
+      pClass = "govuk-body govuk-!-margin-bottom-9",
+      linkSentence = true,
+      openInNewTab = true
     )
 
     GuidanceRow(

--- a/app/viewmodels/PostponedVatViewModel.scala
+++ b/app/viewmodels/PostponedVatViewModel.scala
@@ -193,8 +193,7 @@ object PostponedVatViewModel {
       pvEmail.emailAddress,
       location = pvEmail.emailAddressHref,
       preLinkMessage = Some("cf.account.pvat.older-statements.description.3"),
-      linkSentence
-       = true
+      linkSentence = true
     )
 
     GuidanceRow(

--- a/app/views/components/link.scala.html
+++ b/app/views/components/link.scala.html
@@ -28,11 +28,12 @@
    preLinkMessage: Option[String] = None,
    postLinkMessage: Option[String] = None,
    pId: Option[String] = None,
-   pClass: String = "govuk-body"
+   pClass: String = "govuk-body",
+   openInNewTab: Boolean = false
 )(implicit messages: Messages)
 
 @link = {
-  <a @{linkId.fold(emptyString)(id => s"id=$id")} class="@linkClass" href="@location"><span>@Html(messages(linkMessage))</span>@if(ariaLabel.isDefined){
+  <a @{linkId.fold(emptyString)(id => s"id=$id")} class="@linkClass" target="@{if (openInNewTab) "_blank" else "_self"}" rel="noopener noreferrer" href="@location"><span>@Html(messages(linkMessage))</span>@if(ariaLabel.isDefined){
       <span class="govuk-visually-hidden">@ariaLabel</span>
     }</a>@if(linkSentence){@period}
 }

--- a/app/views/components/link.scala.html
+++ b/app/views/components/link.scala.html
@@ -33,7 +33,13 @@
 )(implicit messages: Messages)
 
 @link = {
-  <a @{linkId.fold(emptyString)(id => s"id=$id")} class="@linkClass" target="@{if (openInNewTab) "_blank" else "_self"}" rel="noopener noreferrer" href="@location"><span>@Html(messages(linkMessage))</span>@if(ariaLabel.isDefined){
+  <a 
+    @{linkId.fold(emptyString)(id => s"id=$id")} 
+    class="@linkClass" 
+    target="@{if (openInNewTab) "_blank" else "_self"}" 
+    rel="noopener noreferrer" 
+    href="@location"
+  ><span>@Html(messages(linkMessage))</span>@if(ariaLabel.isDefined){
       <span class="govuk-visually-hidden">@ariaLabel</span>
     }</a>@if(linkSentence){@period}
 }

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ lazy val microservice = Project(appName, file("."))
     scalafmtPrintDiff := true,
     scalafmtFailOnErrors := true
   )
-  .settings(resolvers += Resolver.jcenterRepo)
 
 lazy val scoverageSettings =
   Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -97,20 +97,6 @@ auditing {
   enabled = true
 }
 
-controllers {
-  controllers.Assets = {
-    needsAuditing = false
-  }
-
-  uk.gov.hmrc.govukfrontend.controllers.Assets = {
-    needsAuditing = false
-  }
-
-  uk.gov.hmrc.hmrcfrontend.controllers.Assets = {
-      needsAuditing = false
-  }
-}
-
 play.i18n.langCookieHttpOnly: "true"
 
 tracking-consent-frontend {

--- a/conf/messages
+++ b/conf/messages
@@ -29,7 +29,7 @@ cf.account.pvat.your-statements.heading=Your statements for the last 6 months
 cf.account.pvat.older-statements.heading=Statements older than 6 months
 cf.account.pvat.older-statements.description.1=There are 2 ways to request statements.
 cf.account.pvat.older-statements.description.2=For declarations made using the Customs Declaration Service,
-cf.account.pvat.older-statements.description.link=complete and send a statement request.
+cf.account.pvat.older-statements.description.link=complete and send a statement request
 cf.account.pvat.older-statements.description.3=For declarations made using CHIEF, email your request to
 # ------------------------------------------------------------------------
 

--- a/conf/messages
+++ b/conf/messages
@@ -126,10 +126,10 @@ cf.account.vat.unavailable=Sorry, your certificates are not available at the mom
 cf.account.vat.statements.unavailable = There were no certificates in {0}.
 cf.account.vat.support.heading=Help and support
 cf.account.vat.support.message=If you need help with import VAT contact
-cf.account.vat.support.link=Imports and exports: general enquiries (opens in new tab).
+cf.account.vat.support.link=Imports and exports: general enquiries (opens in new tab)
 cf.account.vat.older-certificates.heading=Certificates older than 6 months
 cf.account.vat.older-certificates.description.1=For declarations made using the Customs Declaration Service,
-cf.account.vat.older-certificates.description.link=complete and send a certificate request.
+cf.account.vat.older-certificates.description.link=complete and send a certificate request
 cf.account.vat.chief.heading=Declarations made using CHIEF
 cf.account.vat.older-certificates.description.2=C79 certificates are sent to you in the post. If you need a copy of a certificate email your request to
 # ------------------------------------------------------------------------

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -30,7 +30,7 @@ cf.account.pvat.your-statements.heading=Eich datganiadau ar gyfer y 6 mis diweth
 cf.account.pvat.older-statements.heading=Datganiadau sy’n hŷn na 6 mis
 cf.account.pvat.older-statements.description.1=Mae 2 ffordd i ofyn am ddatganiadau.
 cf.account.pvat.older-statements.description.2=Ar gyfer datganiadau a wnaed gan ddefnyddio’r Gwasanaeth Datganiadau Tollau,
-cf.account.pvat.older-statements.description.link=llenwch ac anfon cais am ddatganiad.
+cf.account.pvat.older-statements.description.link=llenwch ac anfon cais am ddatganiad
 cf.account.pvat.older-statements.description.3=Ar gyfer datganiadau a wneir gan ddefnyddio’r gwasanaeth CHIEF, e-bostiwch eich cais i
 # ------------------------------------------------------------------------
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -118,7 +118,7 @@ cf.account.vat.support.heading=Help a chymorth
 cf.account.vat.available-text=Fel arfer, bydd eich tystysgrifau ar gael ar ôl 10fed diwrnod gwaith o pob mis.
 cf.account.vat.your-certificates.heading=Eich tystysgrifau ar gyfer y chwe mis diwethaf
 cf.account.vat.support.message=Os oes angen help arnoch gyda TAW mewnforio, cysylltwch â’r
-cf.account.vat.support.link=Llinell Gymorth TAW ac Ecséis (yn agor mewn tab newydd).
+cf.account.vat.support.link=Llinell Gymorth TAW ac Ecséis (yn agor mewn tab newydd)
 cf.account.vat.title=Tystysgrifau TAW mewnforio (C79)
 cf.account.vat.missing-file=Nid yw ar gael
 cf.account.vat.download-link=Lawrlwytho {0} o {1} ({2})
@@ -130,7 +130,7 @@ cf.account.vat.unavailable=Mae’n ddrwg gennym, nid yw’ch tystysgrifau ar gae
 cf.account.vat.statements.unavailable = Nid oedd unrhyw dystysgrifau i mewn {0}.
 cf.account.vat.older-certificates.heading=Tystysgrifau sy’n hŷn na 6 mis
 cf.account.vat.older-certificates.description.1=Ar gyfer datganiadau a wnaed gan ddefnyddio’r Gwasanaeth Datganiadau Tollau,
-cf.account.vat.older-certificates.description.link=llenwi ac anfon cais am dystysgrif.
+cf.account.vat.older-certificates.description.link=llenwi ac anfon cais am dystysgrif
 cf.account.vat.chief.heading=Datganiadau a wnaed gan ddefnyddio’r gwasanaeth CHIEF
 cf.account.vat.older-certificates.description.2=Caiff tystysgrifau C79 eu hanfon atoch drwy’r post. Os oes angen copi o dystysgrif arnoch, anfonwch eich cais drwy e-bost at
 # ------------------------------------------------------------------------

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.11.0"
+  val bootstrapVersion = "9.12.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.7")
 addSbtPlugin("com.github.sbt" % "sbt-gzip" % "2.0.0")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")

--- a/test/viewmodels/ImportVatViewModelSpec.scala
+++ b/test/viewmodels/ImportVatViewModelSpec.scala
@@ -153,7 +153,8 @@ class ImportVatViewModelSpec extends SpecBase {
         linkComponent(
           "cf.account.vat.older-certificates.description.link",
           location = URL_TEST,
-          preLinkMessage = Some("cf.account.vat.older-certificates.description.1")
+          preLinkMessage = Some("cf.account.vat.older-certificates.description.1"),
+          linkSentence = true
         )
       )
     )
@@ -172,7 +173,8 @@ class ImportVatViewModelSpec extends SpecBase {
         linkComponent(
           appConfig.c79EmailAddress,
           location = appConfig.c79EmailAddressHref,
-          preLinkMessage = Some("cf.account.vat.older-certificates.description.2")
+          preLinkMessage = Some("cf.account.vat.older-certificates.description.2"),
+          linkSentence = true
         )
       )
     )
@@ -186,20 +188,13 @@ class ImportVatViewModelSpec extends SpecBase {
         msg = "cf.account.vat.support.heading",
         classes = "govuk-heading-m govuk-!-margin-top-2"
       ),
-      paragraph = Some(
-        pComponent(
-          message = "cf.account.vat.support.message",
-          classes = "govuk-body govuk-!-margin-bottom-9",
-          tabLink = Some(
-            new HmrcNewTabLink().apply(
-              NewTabLink(
-                language = Some(messages.lang.toString),
-                classList = Some("govuk-link"),
-                href = Some(appConfig.viewVatAccountSupportLink),
-                text = messages("cf.account.vat.support.link")
-              )
-            )
-          )
+      link = Some(
+        linkComponent(
+          preLinkMessage = Some("cf.account.vat.support.message"),
+          linkMessage = "cf.account.vat.support.link",
+          location = appConfig.viewVatAccountSupportLink,
+          openInNewTab = true,
+          linkSentence = true
         )
       )
     )

--- a/test/viewmodels/PostponedVatViewModelSpec.scala
+++ b/test/viewmodels/PostponedVatViewModelSpec.scala
@@ -438,7 +438,8 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
         linkComponent.apply(
           "cf.account.pvat.older-statements.description.link",
           location = serviceUnavailableUrl,
-          preLinkMessage = Some("cf.account.pvat.older-statements.description.2")
+          preLinkMessage = Some("cf.account.pvat.older-statements.description.2"),
+          linkSentence = true
         )
       )
     )
@@ -453,7 +454,8 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
         linkComponent.apply(
           pvEmailEmailAddress,
           location = pvEmailEmailAddressHref,
-          preLinkMessage = Some("cf.account.pvat.older-statements.description.3")
+          preLinkMessage = Some("cf.account.pvat.older-statements.description.3"),
+          linkSentence = true
         )
       )
     )
@@ -469,9 +471,10 @@ class PostponedVatViewModelSpec extends SpecBase with GuiceOneAppPerSuite {
           messages("cf.account.pvat.support.link"),
           location = viewVatAccountSupportLink,
           preLinkMessage = Some("cf.account.pvat.support.message"),
-          postLinkMessage = Some(period),
           pId = Some("pvat.support.message"),
-          pClass = "govuk-body govuk-!-margin-bottom-9"
+          pClass = "govuk-body govuk-!-margin-bottom-9",
+          linkSentence = true,
+          openInNewTab = true
         )
       )
     )


### PR DESCRIPTION
The initial DAC assessment of the CDS Financials service has identified some ares for improvement to align with the government’s WACG. Some adjustments need to be made before our upcoming retest of the DAC. This ticket is for the PVAT statements page. 

Note: I also found that the open in new tab link was not connected to a new tab link component 

so i added a param to the existing link wrapper to enable this 